### PR TITLE
온보딩 도중 이탈한 사용자 예외처리 및 기타 UX 에러 수정

### DIFF
--- a/src/components/matching/MatchingSignalInputBox.tsx
+++ b/src/components/matching/MatchingSignalInputBox.tsx
@@ -78,6 +78,7 @@ export default function MatchingSignalInputBox({
         className="ml-2 flex-1 bg-transparent text-xs text-gray-500 outline-none placeholder:text-gray-400"
       />
       <button
+        type="button"
         onClick={handleSend}
         className="ml-2 flex h-6 w-6 items-center justify-center rounded-full bg-white shadow"
       >

--- a/src/components/matching/MatchingSignalInputBox.tsx
+++ b/src/components/matching/MatchingSignalInputBox.tsx
@@ -52,7 +52,7 @@ export default function MatchingSignalInputBox({
         if (code === 'USER_DEACTIVATED') {
           toast.error('상대방이 탈퇴한 사용자입니다.');
         } else if (code === 'ALREADY_IN_CONVERSATION') {
-          toast.error('이미 대화 중인 상대방입니다.');
+          toast('상대방이 먼저 채팅을 시작했습니다. 채팅방을 확인해주세요!', { icon: '👋🏻' });
         } else {
           toast.error('시그널 전송에 실패했습니다.');
         }

--- a/src/components/matching/individual/KeywordTagGroup.tsx
+++ b/src/components/matching/individual/KeywordTagGroup.tsx
@@ -27,8 +27,13 @@ export default function KeywordTagGroup({
       <div className="mb-4 space-y-1.5">
         <p className="font-semibold">함께 나누는 공통 관심사에요</p>
       </div>
-
-      <KeywordTag keywords={commonInterestList} variant="common" />
+      {commonInterestList.length > 0 ? (
+        <KeywordTag keywords={commonInterestList} variant="common" />
+      ) : (
+        <p className="items-center justify-center text-sm font-light text-[var(--gray-300)]">
+          공통 관심사가 존재하지 않습니다.
+        </p>
+      )}
     </main>
   );
 }

--- a/src/components/onboarding/information/OnboardingInformationWrapper.tsx
+++ b/src/components/onboarding/information/OnboardingInformationWrapper.tsx
@@ -29,9 +29,14 @@ export default function OnboardingInformationWrapper() {
           sessionStorage.setItem('providerId', response.data.providerId);
           setProviderId(response.data.providerId);
           setIsNewUser(true);
+          return;
         } else if (response.code === 'USER_ALREADY_REGISTERED') {
           localStorage.setItem('accessToken', response.data.accessToken);
           router.replace('/home');
+          return;
+        } else if (response.code === 'USER_INTERESTS_NOT_SELECTED') {
+          localStorage.setItem('accessToken', response.data.accessToken);
+          router.replace('/onboarding/interests');
         } else if (response.code === 'OAUTH_STATE_INVALID') {
           toast.error('잘못된 접근입니다.');
           router.replace('/not-found');

--- a/src/components/onboarding/interests/EnumSelectGrid.tsx
+++ b/src/components/onboarding/interests/EnumSelectGrid.tsx
@@ -40,7 +40,9 @@ export const EnumSelectGrid = (props: EnumSelectGridProps) => {
           onSelect(current.filter((item) => item !== key));
         } else {
           if (current.length >= maxSelect) {
-            toast.error(`최대 ${maxSelect}개까지만 선택할 수 있어요`);
+            toast.error(`최대 ${maxSelect}개까지만 선택할 수 있어요`, {
+              id: 'max-select-limit',
+            });
             return;
           }
           onSelect([...current, key]);


### PR DESCRIPTION
### 🚀 연관된 이슈
- #20 
<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
- 온보딩 이탈 사용자에 대한 repsonse인 `USER_INTERESTS_NOT_SELECTED` 연결 및 로직 구현
- <input>에서 Enter 키를 누르면 button 클릭 이벤트까지 중복 호출하는 문제 수정
- 온보딩 중 10개 이상 클릭 시 뜨는 토스트 메세지 다중 호출 방지를 위한 id 부여
- 튜닝 페이지 공통 관심사 존재하지 않을 때 안내 문구 구현
- 시그널 보내는 도중 채팅방 생성 시 알림 처리


<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     | 신규 기능 / 기능 개선 / 버그 수정 / UI 변경 등         |
