### PR TITLE
CICI에서 CD 실패 시 rollback으로 넘어가지 않는 오류 수정 (#55)

### DIFF
--- a/.github/workflows/cicd-frontend.yml
+++ b/.github/workflows/cicd-frontend.yml
@@ -11,9 +11,9 @@ on:
   workflow_dispatch:
     inputs:
       env:
-        description: '배포 환경 선택'
+        description: "배포 환경 선택"
         required: true
-        default: 'DEV'
+        default: "DEV"
         type: choice
         options:
           - DEV
@@ -139,9 +139,6 @@ jobs:
   frontend-cd:
     # needs: frontend-ci
     runs-on: ubuntu-latest
-    outputs:
-      deploy_status: ${{ steps.set-result.outputs.status }}
-      target_branch: ${{ steps.set-result.outputs.branch }}
     steps:
       # # ✅ act 테스트용 필요 패키지 설치 (명령어: act workflow_dispatch -W .github/workflows/cicd-frontend.yml -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest)
       # - name: Install required tools
@@ -206,7 +203,7 @@ jobs:
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v1
         with:
-          credentials_json: '${{ env.SA_KEY }}'
+          credentials_json: "${{ env.SA_KEY }}"
 
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v1
@@ -248,7 +245,6 @@ jobs:
           sleep 15
 
       - name: Health check with retries
-        id: set-result
         run: |
           echo "🔍 헬스체크 시작: 최대 3회 시도합니다."
           if [[ "${{ env.ENV }}" == "PROD" ]]; then
@@ -261,7 +257,6 @@ jobs:
             echo "⏱️ 시도 $i: $CHECK_URL"
             if curl -sf --connect-timeout 5 --max-time 10 "$CHECK_URL"; then
               echo "✅ 헬스체크 성공 🎉"
-              echo "status=success" >> $GITHUB_OUTPUT
               exit 0
             else
               echo "::error::헬스체크 시도 $i 실패"
@@ -270,13 +265,11 @@ jobs:
           done
 
           echo "::error::❌ 3회 헬스체크 실패 - 서버가 정상 기동되지 않음"
-          echo "status=failure" >> $GITHUB_OUTPUT
-          exit 0
+          exit 1
 
       - name: Send failure notification
-        if: failure() || steps.set-result.outputs.status == 'failure'
+        if: failure()
         run: |
-          echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           WORKFLOW_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           curl -H "Content-Type: application/json" \
               -X POST \
@@ -284,7 +277,7 @@ jobs:
               ${{ secrets.DISCORD_WEBHOOK_CICD_URL }}
 
       - name: Send success notification
-        if: steps.set-result.outputs.status == 'success'
+        if: success()
         run: |
           curl -H "Content-Type: application/json" \
                -X POST \
@@ -293,7 +286,7 @@ jobs:
 
   frontend-rollback:
     needs: frontend-cd
-    if: needs.frontend-cd.outputs.deploy_status == 'failure'
+    if: always() && needs.frontend-cd.result != 'success'
     runs-on: ubuntu-latest
     steps:
       # # ✅ act 테스트용 필요 패키지 설치
@@ -359,7 +352,7 @@ jobs:
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v1
         with:
-          credentials_json: '${{ env.SA_KEY }}'
+          credentials_json: "${{ env.SA_KEY }}"
 
       - name: Setup gcloud CLI
         uses: google-github-actions/setup-gcloud@v1
@@ -380,6 +373,11 @@ jobs:
           script: |
             cd /home/deploy
             ./fe_deploy.sh --rollback || exit 1
+
+      - name: Wait for Next.JS to start
+        run: |
+          echo "🕒 Next.JS 서버 기동 대기 중..."
+          sleep 15
 
       - name: Health check with retries
         run: |


### PR DESCRIPTION
### 🚀 연관된 이슈
- x

---

### 📝 작업 내용

- cd 실패 exit 1로 종료되는 트리거를 rollback job에서 인식하지 못해 문제가 생김
- rollback job의 트리거에 `if: always() && needs.frontend-cd.result != 'success'`를 설정
- cd job에서 exit 1을 뱉고 끝내더라도, rollback job에 `always()`를 넣어 해당 job을 인식하게 설정하고, `&& needs.frontend-cd.result != 'success'` 조건을 추가로 걸어 cd job이 실패했을 때만 수행됨

---

### 🛠 변경 사항 요약

- x

### ✅ 테스트 목록

- [x] 로컬에서 act로 스크립트가 정상동작 하는걸 확인

---

### 📎 참고 자료

- x
---

### 📌 기타

- x
