### PR TITLE
하단 네비게이션 리팩토링 및 배경 그림자 추가로 UI 개선

### DIFF
--- a/src/components/layout/BottomNavigationBar.tsx
+++ b/src/components/layout/BottomNavigationBar.tsx
@@ -8,6 +8,13 @@ import { FaRegUserCircle } from 'react-icons/fa';
 
 const hiddenRoutes = ['/login', '/onboarding', '/not-found'];
 
+const navItems = [
+  { path: '/home', label: '홈', icon: HiOutlineHome },
+  { path: '/report', label: '리포트', icon: TbReportSearch },
+  { path: '/chat', label: '채널', icon: PiChatCircleDotsBold },
+  { path: '/mypage', label: '마이페이지', icon: FaRegUserCircle },
+];
+
 export default function BottomNavigationBar() {
   const pathname = usePathname();
   const router = useRouter();
@@ -16,35 +23,25 @@ export default function BottomNavigationBar() {
   if (shouldHide) return null;
 
   return (
-    <nav className="fixed bottom-0 z-50 flex h-[3.5rem] w-full max-w-[430px] items-center justify-around border-t bg-white pb-[env(safe-area-inset-bottom)]">
-      <button
-        onClick={() => router.push('/home')}
-        className="flex flex-col items-center gap-1 text-xs"
-      >
-        <HiOutlineHome className="h-5 w-5" />
-        <p className="text-[0.7rem] font-medium">홈</p>
-      </button>
-      <button
-        onClick={() => router.push('/report')}
-        className="flex flex-col items-center gap-1 text-xs"
-      >
-        <TbReportSearch className="h-5 w-5" />
-        <p className="text-[0.7rem] font-medium">리포트</p>
-      </button>
-      <button
-        onClick={() => router.push('/chat')}
-        className="flex flex-col items-center gap-1 text-xs"
-      >
-        <PiChatCircleDotsBold className="h-[18px] w-[18px]" />
-        <p className="text-[0.7rem] font-medium">채널</p>
-      </button>
-      <button
-        onClick={() => router.push('/mypage')}
-        className="flex flex-col items-center gap-1 text-xs"
-      >
-        <FaRegUserCircle className="h-[18px] w-[18px]" />
-        <p className="text-[0.7rem] font-medium">마이페이지</p>
-      </button>
+    <nav className="fixed bottom-0 z-50 flex h-[3.5rem] w-full max-w-[430px] items-center justify-around bg-white pb-[env(safe-area-inset-bottom)] shadow-[0_-2px_10px_rgba(0,0,0,0.05)] before:absolute before:top-0 before:h-2 before:w-full before:bg-gradient-to-t before:from-white before:to-transparent">
+      {navItems.map(({ path, label, icon: Icon }) => {
+        const isActive = pathname === path;
+
+        return (
+          <button
+            key={path}
+            onClick={() => router.push(path)}
+            className={`flex flex-col items-center gap-1 text-xs transition-colors duration-200 ${
+              isActive ? 'font-semibold text-[var(--gray-400)]' : 'text-[var(--gray-300)]'
+            }`}
+          >
+            <Icon
+              className={`h-5 w-5 transition-transform duration-200 ${isActive ? 'scale-100' : 'scale-90'}`}
+            />
+            <p className="text-[0.7rem] font-semibold">{label}</p>
+          </button>
+        );
+      })}
     </nav>
   );
 }

--- a/src/components/layout/ChatHeader.tsx
+++ b/src/components/layout/ChatHeader.tsx
@@ -16,19 +16,19 @@ export default function ChatHeader({ title, onLeave, onToggleDetail }: ChatHeade
   return (
     <header className="fixed top-0 left-1/2 z-50 flex h-14 w-full max-w-[430px] -translate-x-1/2 items-center justify-between bg-white px-4">
       <button onClick={() => router.back()} className="flex w-6 items-center justify-center p-1">
-        <FaAngleLeft className="text-[clamp(1rem,2.5vw,1.5rem)]" />
+        <FaAngleLeft className="text-[clamp(1rem,2vw,1.2rem)]" />
       </button>
 
       <div
         onClick={onToggleDetail}
-        className="flex max-w-[220px] flex-1 cursor-pointer items-center justify-center overflow-hidden text-lg font-bold whitespace-nowrap text-black"
+        className="flex max-w-[220px] flex-1 cursor-pointer items-center justify-center gap-2 overflow-hidden text-lg font-bold whitespace-nowrap text-black"
       >
         <span className="overflow-hidden text-ellipsis">{title}</span>
-        <FaAngleDown className="ml-1 flex-shrink-0 text-base" />
+        <FaAngleDown className="ml-1 flex-shrink-0 text-[clamp(1rem,2vw,0.8rem)]" />
       </div>
 
       <button onClick={onLeave} className="flex w-8 items-center justify-center p-1">
-        <LuLogOut className="text-[clamp(1rem,2.5vw,1.5rem)]" />
+        <LuLogOut className="text-[clamp(1rem,2vw,1.2rem)]" />
       </button>
     </header>
   );

--- a/src/components/layout/ClientLayoutContent.tsx
+++ b/src/components/layout/ClientLayoutContent.tsx
@@ -40,7 +40,9 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
       }`}
     >
       {!isHiddenUI && <Header title="" showBackButton={false} showNotificationButton={false} />}
-      <div className={`flex-grow overflow-y-auto ${isHiddenUI ? '' : 'pt-[56px] pb-[56px]'}`}>
+      <div
+        className={`flex-grow overflow-y-auto shadow-lg ${isHiddenUI ? '' : 'pt-[56px] pb-[56px]'}`}
+      >
         {children}
       </div>
       {!isHiddenUI && <BottomNavigationBar />}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -30,7 +30,7 @@ export default function Header({
       <div className="flex w-8 items-center">
         {showBackButton && (
           <button onClick={handleBack} className="p-1">
-            <FaAngleLeft className="text-[clamp(1rem,2.5vw,1.2rem)]" />
+            <FaAngleLeft className="text-[clamp(1rem,2vw,1.2rem)]" />
           </button>
         )}
       </div>
@@ -40,7 +40,7 @@ export default function Header({
       <div>
         {showNotificationButton ? (
           <button className="p-1">
-            <FaRegBell className="text-[clamp(1rem,2.5vw,1.2rem)]" />
+            <FaRegBell className="text-[clamp(1rem,2vw,1.2rem)]" />
           </button>
         ) : (
           <div className="w-5" />


### PR DESCRIPTION
### 🚀 연관된 이슈
- #57 
<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
- 헤더 아이콘 크기 조정
- 모바일 콘텐츠 영역에 그림자 효과 추가
- 하단 네비게이션 버튼 map 기반 리팩토링 및 UI 개선 (그림자 효과 추가, 항목 클릭 시 UI 변경)

<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->
<img width="516" alt="image" src="https://github.com/user-attachments/assets/d70c95b5-de4d-425f-a8e6-9e667c902dac" />

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     |  UI 변경        |