### PR TITLE
v1.0.3

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -151,3 +151,12 @@ body {
     font-size: 16px !important;
   }
 }
+
+.scrollbar-none {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}

--- a/src/app/onboarding/interests/page.tsx
+++ b/src/app/onboarding/interests/page.tsx
@@ -8,14 +8,16 @@ const UserPreferenceForm = dynamic(
   () => import('@/components/onboarding/interests/UserPreferenceForm'),
   { ssr: false },
 );
+
 export default function OnboardingInterestsPage() {
   const [step, setStep] = useState(1);
+
   return (
-    <>
+    <div className="mx-auto flex h-screen max-w-[430px] flex-col">
       <Header title="취향 선택하기" showBackButton={step > 1} showNotificationButton={false} />
-      <main className="overflow-y-auto p-4">
+      <div className="flex-1 px-4 pt-4">
         <UserPreferenceForm onStepChange={setStep} />
-      </main>
-    </>
+      </div>
+    </div>
   );
 }

--- a/src/components/common/CommonKeyword.tsx
+++ b/src/components/common/CommonKeyword.tsx
@@ -1,7 +1,0 @@
-export default function CommonKeyword() {
-  return (
-    <main>
-      <div className="border-1 border-[var(--gray-200)]">ESTP</div>
-    </main>
-  );
-}

--- a/src/components/common/KeywordTag.tsx
+++ b/src/components/common/KeywordTag.tsx
@@ -16,20 +16,20 @@ import {
 } from '@/constants/enum';
 
 const ALL_KEYWORD_MAP = {
-  ...AgeGroup,
-  ...Gender,
-  ...Religion,
-  ...Smoking,
-  ...Drinking,
-  ...MBTI,
-  ...Personality,
-  ...PreferredPeople,
-  ...CurrentInterests,
-  ...FavoriteFoods,
-  ...LikedSports,
-  ...Pets,
-  ...SelfDevelopment,
-  ...Hobbies,
+  ...prefixEnum('AGE', AgeGroup),
+  ...prefixEnum('GENDER', Gender),
+  ...prefixEnum('RELIGION', Religion),
+  ...prefixEnum('SMOKING', Smoking),
+  ...prefixEnum('DRINKING', Drinking),
+  ...prefixEnum('MBTI', MBTI),
+  ...prefixEnum('PERSONALITY', Personality),
+  ...prefixEnum('PREFERRED_PEOPLE', PreferredPeople),
+  ...prefixEnum('CURRENT_INTERESTS', CurrentInterests),
+  ...prefixEnum('FAVORITE_FOODS', FavoriteFoods),
+  ...prefixEnum('LIKED_SPORTS', LikedSports),
+  ...prefixEnum('PETS', Pets),
+  ...prefixEnum('SELF_DEVELOPMENT', SelfDevelopment),
+  ...prefixEnum('HOBBIES', Hobbies),
 };
 
 interface KeywordTagProps {
@@ -37,16 +37,32 @@ interface KeywordTagProps {
   variant?: 'default' | 'common';
 }
 
+// enum 객체의 key 중복을 방지하기 위해 prefix를 붙여 새로운 객체로 변환
+function prefixEnum<T extends Record<string, string>>(
+  prefix: string,
+  obj: T,
+): Record<string, string> {
+  return Object.entries(obj).reduce(
+    (acc, [key, value]) => {
+      acc[`${prefix}_${key}`] = value;
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
+}
+
 export default function KeywordTag({ keywords, variant = 'default' }: KeywordTagProps) {
   const isCommon = variant === 'common';
 
   return (
     <div className="flex flex-wrap gap-2">
-      {keywords.map((keyword, i) => {
-        const label = ALL_KEYWORD_MAP[keyword as keyof typeof ALL_KEYWORD_MAP] || keyword;
+      {keywords.map((keywordWithPrefix, i) => {
+        const label =
+          ALL_KEYWORD_MAP[keywordWithPrefix as keyof typeof ALL_KEYWORD_MAP] || keywordWithPrefix;
 
-        const isPreferredPeople = Object.keys(PreferredPeople).includes(keyword);
-        const displayLabel = isPreferredPeople ? `👩🏻‍❤️‍👨🏻 ${label}` : label;
+        const rawKeyword = keywordWithPrefix.split('_').slice(1).join('_');
+        const isPreferredPeople = Object.keys(PreferredPeople).includes(rawKeyword);
+        const displayLabel = isPreferredPeople ? `👩🏻‍❤️‍👨🏻${label}` : label;
 
         return (
           <div

--- a/src/components/matching/individual/KeywordTagGroup.tsx
+++ b/src/components/matching/individual/KeywordTagGroup.tsx
@@ -2,7 +2,12 @@
 
 import KeywordTag from '@/components/common/KeywordTag';
 import { TuningKeywords, TuningSameInterests } from '@/lib/api/matching';
+import { useEffect } from 'react';
 
+interface Tag {
+  key: string;
+  label: string;
+}
 interface KeywordTagGroupProps {
   keywords: TuningKeywords;
   sameInterests: TuningSameInterests;
@@ -14,8 +19,20 @@ export default function KeywordTagGroup({
   sameInterests,
   nickname,
 }: KeywordTagGroupProps) {
-  const keywordList = Object.values(keywords);
-  const commonInterestList = Object.values(sameInterests).flat();
+  // 사용자 키워드를 렌더링용 문자열 배열로 변환 ('preferredPeople': 'RELIABLE' → 'PREFERRED_PEOPLE_RELIABLE')
+  const keywordList = Object.entries(keywords).map(
+    ([category, key]) => `${category.toUpperCase()}_${key}`,
+  );
+
+  const commonInterestList = Object.entries(sameInterests).flatMap(([category, keys]) => {
+    const normalizedCategory = normalizeCategory(category);
+    return keys.map((key: Tag) => `${normalizedCategory}_${key}`);
+  });
+
+  //  camelCase → SNAKE_CASE 변환 유틸 함수'preferredPeople' → 'PREFERRED_PEOPLE'
+  function normalizeCategory(category: string) {
+    return category.replace(/([a-z])([A-Z])/g, '$1_$2').toUpperCase();
+  }
 
   return (
     <main className="space-y-4 px-4">


### PR DESCRIPTION
### 🚀 연관된 이슈

<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
**enum 키워드 중복 방지를 위한 prefixEnum 적용**

- prefixEnum 유틸 도입으로 enum 키 중복 문제 해결
- `ALL_KEYWORD_MAP` 구조 정비
- 공통 관심사 키워드 중 선호하는 상대방 성향에만 이모지 적용 ( 👩🏻‍❤️‍👨🏻)

**키워드 데이터에 prefix 적용 및 렌더링 일관성 확보**

- 사용자 키워드와 공통 키워드 모두 '카테고리_KEY' 포맷으로 변환
- `normalizeCategory` 유틸 함수 추가로 camelCase → SNAKE_CASE 변환
- KeywordTag 컴포넌트와 포맷 일관성을 유지하도록 리팩토링

**불필요한 키워드 컴포넌트 제거 및 온보딩 UI 수정**
<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     |  버그 수정  |