### PR TITLE
매칭 SSE 수락/거절 API 연동 및 채팅방 UI 동적 반영

### DIFF
--- a/src/app/chat/individual/[channelRoomId]/page.tsx
+++ b/src/app/chat/individual/[channelRoomId]/page.tsx
@@ -119,9 +119,14 @@ export default function ChatsIndividualPage() {
                     contents={msg.messageContents}
                     sentAt={msg.messageSendAt}
                     partnerId={partner?.partnerId ?? null}
+                    relationType={partner?.relationType ?? null}
                   />
                 ) : (
-                  <SenderMessage contents={msg.messageContents} sentAt={msg.messageSendAt} />
+                  <SenderMessage
+                    contents={msg.messageContents}
+                    sentAt={msg.messageSendAt}
+                    relationType={partner?.relationType ?? null}
+                  />
                 )}
               </div>
             );

--- a/src/app/chat/individual/page.tsx
+++ b/src/app/chat/individual/page.tsx
@@ -70,7 +70,7 @@ export default function ChannelsIndividualPage() {
                   className="h-full w-full rounded-full object-cover"
                 />
                 {!room.isRead && (
-                  <span className="absolute right-0 bottom-0 h-3.5 w-3.5 rounded-full border-2 border-white bg-pink-400" />
+                  <span className="absolute right-0 bottom-0 h-3.5 w-3.5 rounded-full border-2 border-white bg-[var(--pink)]" />
                 )}
               </div>
 
@@ -81,10 +81,16 @@ export default function ChannelsIndividualPage() {
                       className={`rounded-2xl px-2 py-1 text-xs font-semibold ${
                         room.relationType === 'SIGNAL'
                           ? 'bg-[var(--gray-100)] text-[var(--blue)]'
-                          : 'bg-[var(--light-pink)] text-[var(--pink)]'
+                          : room.relationType === 'MATCHING'
+                            ? 'bg-[var(--light-pink)] text-[var(--pink)]'
+                            : 'bg-[var(--gray-100)] text-[var(--gray-300)]'
                       }`}
                     >
-                      {room.relationType === 'SIGNAL' ? '시그널' : '매칭'}
+                      {room.relationType === 'SIGNAL'
+                        ? '시그널'
+                        : room.relationType === 'MATCHING'
+                          ? '매칭'
+                          : '실패'}
                     </span>
                     <span className="text-sm font-semibold text-ellipsis">
                       {room.partnerNickname}

--- a/src/app/profile/[partnerId]/page.tsx
+++ b/src/app/profile/[partnerId]/page.tsx
@@ -1,25 +1,25 @@
 'use client';
 
+import { useParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import Header from '@/components/layout/Header';
 import KeywordTagGroup from '@/components/matching/individual/KeywordTagGroup';
 import UserProfileCard from '@/components/mypage/UserProfileCard';
 import { getUserInfo, GetUserInfoResponse } from '@/lib/api/user';
-import { useEffect, useState } from 'react';
 
 export default function ProfileDetailPage() {
+  const { partnerId } = useParams() as { partnerId: string };
   const [userInfo, setUserInfo] = useState<GetUserInfoResponse['data'] | null>(null);
 
   useEffect(() => {
     const fetchUserInfo = async () => {
       try {
-        const userId = localStorage.getItem('userId');
-
-        if (!userId) {
-          console.error('userId가 없습니다.');
+        if (!partnerId) {
+          console.error('partnerId가 없습니다.');
           return;
         }
-        const response = await getUserInfo(userId);
+        const response = await getUserInfo(partnerId);
         setUserInfo(response.data);
       } catch (error) {
         console.error('유저 정보 불러오기 실패: ', error);
@@ -27,7 +27,7 @@ export default function ProfileDetailPage() {
     };
 
     fetchUserInfo();
-  }, []);
+  }, [partnerId]);
 
   if (!userInfo) {
     return <LoadingSpinner />;

--- a/src/components/chat/common/ReceiverMessage.tsx
+++ b/src/components/chat/common/ReceiverMessage.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import clsx from 'clsx';
 import dayjs from 'dayjs';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
@@ -10,6 +11,7 @@ interface ReceiverMessageProps {
   contents: string;
   sentAt: string;
   partnerId: number;
+  relationType: 'SIGNAL' | 'MATCHING' | 'UNMATCHED';
 }
 
 export default function ReceiverMessage({
@@ -18,6 +20,7 @@ export default function ReceiverMessage({
   contents,
   sentAt,
   partnerId,
+  relationType,
 }: ReceiverMessageProps) {
   const router = useRouter();
 
@@ -37,7 +40,14 @@ export default function ReceiverMessage({
   return (
     <div className="flex items-start justify-start gap-1.5">
       <div className="mr-2 flex flex-col items-center">
-        <div className="relative h-10 w-10 rounded-full bg-gradient-to-tr from-[#7BA1FF] via-[#7BA1FF] to-transparent p-[2px]">
+        <div
+          className={clsx(
+            'relative h-10 w-10 rounded-full bg-gradient-to-tr to-transparent p-[2px]',
+            relationType === 'MATCHING'
+              ? 'from-[var(--pink)] via-[#FF73B7]'
+              : 'from-[#7BA1FF] via-[#7BA1FF]',
+          )}
+        >
           <div onClick={handleProfileClick} className="h-full w-full rounded-full bg-white">
             <Image
               src={getSafeImageSrc(profileImage) || '/images/default-profile.png'}
@@ -54,7 +64,12 @@ export default function ReceiverMessage({
         <p className="mt-1 text-sm font-semibold text-[var(--gray-400)]">{nickname}</p>
         <div className="mt-1.5 flex pr-4">
           <div className="flex max-w-[16rem] items-end gap-2">
-            <div className="inline-block rounded-3xl border border-[var(--blue)] bg-white px-4 py-2 text-xs leading-[1.4] break-all whitespace-pre-wrap text-black">
+            <div
+              className={clsx(
+                'inline-block rounded-3xl border bg-white px-4 py-2 text-xs leading-[1.4] break-all whitespace-pre-wrap text-black',
+                relationType === 'MATCHING' ? 'border-[var(--pink)]' : 'border-[var(--blue)]',
+              )}
+            >
               {contents}
             </div>
             <p className="mt-1 text-xs text-[var(--gray-300)]">{dayjs(sentAt).format('HH:mm')}</p>

--- a/src/components/chat/common/SenderMessage.tsx
+++ b/src/components/chat/common/SenderMessage.tsx
@@ -1,18 +1,25 @@
 'use client';
 
+import clsx from 'clsx';
 import dayjs from 'dayjs';
 
 interface SenderMessageProps {
   contents: string;
   sentAt: string;
+  relationType: 'SIGNAL' | 'MATCHING' | 'UNMATCHED' | null;
 }
 
-export default function SenderMessage({ contents, sentAt }: SenderMessageProps) {
+export default function SenderMessage({ contents, sentAt, relationType }: SenderMessageProps) {
   return (
     <div className="flex items-end justify-end gap-2 pr-4 whitespace-pre-wrap">
       <p className="mt-1 text-xs text-[var(--gray-300)]">{dayjs(sentAt).format('HH:mm')}</p>
       <div className="max-w-[14rem]">
-        <div className="inline-block rounded-3xl border border-[var(--blue)] bg-white px-4 py-2 text-xs leading-[1.4] break-all text-black">
+        <div
+          className={clsx(
+            'inline-block rounded-3xl border bg-white px-4 py-2 text-xs leading-[1.4] break-all text-black',
+            relationType === 'MATCHING' ? 'border-[var(--pink)]' : 'border-[var(--blue)]',
+          )}
+        >
           {contents}
         </div>
       </div>

--- a/src/components/layout/ChatHeader.tsx
+++ b/src/components/layout/ChatHeader.tsx
@@ -24,7 +24,7 @@ export default function ChatHeader({ title, onLeave, onToggleDetail }: ChatHeade
         className="flex max-w-[220px] flex-1 cursor-pointer items-center justify-center gap-2 overflow-hidden text-lg font-bold whitespace-nowrap text-black"
       >
         <span className="overflow-hidden text-ellipsis">{title}</span>
-        <FaAngleDown className="ml-1 flex-shrink-0 text-[clamp(1rem,2vw,0.8rem)]" />
+        {/* <FaAngleDown className="ml-1 flex-shrink-0 text-[clamp(1rem,2vw,0.8rem)]" /> */}
       </div>
 
       <button onClick={onLeave} className="flex w-8 items-center justify-center p-1">

--- a/src/components/layout/ClientLayoutContent.tsx
+++ b/src/components/layout/ClientLayoutContent.tsx
@@ -10,6 +10,7 @@ import { useConfirmModalStore } from '@/stores/modal/useConfirmModalStore';
 import { ConfirmModal } from '../common/ConfirmModal';
 import WaitingModal from '../common/WaitingModal';
 import { useWaitingModalStore } from '@/stores/modal/useWaitingModalStore';
+import { postMatchingAccept, postMatchingReject } from '@/lib/api/matching';
 
 const hiddenRoutes = ['/login', '/onboarding', '/not-found'];
 
@@ -21,15 +22,28 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
   const [mounted, setMounted] = useState(false);
   const [padding, setPadding] = useState({ top: 0, bottom: 0 });
   const [isHiddenUI, setIsHiddenUI] = useState(false);
+  const closeConfirmModal = useConfirmModalStore((state) => state.closeModal);
+  const closeWaitingModal = useWaitingModalStore((state) => state.closeModal);
+  const openWaitingModal = useWaitingModalStore((state) => state.openModal);
 
   const sseHandlers = useMemo(
     () => ({
       'signal-matching-conversion': (data: unknown) => {
-        const { partnerNickname } = data as { partnerNickname: string };
+        const { partnerNickname, channelRoomId } = data as {
+          partnerNickname: string;
+          channelRoomId: number;
+        };
         toast.success(`🎉 ${partnerNickname}님과 매칭이 가능해졌어요!`);
       },
       'signal-matching-conversion-in-room': (data: unknown) => {
-        const { partnerNickname } = data as { partnerNickname: string };
+        const { partnerNickname, channelRoomId, hasResponeded, partnerHasResponded } = data as {
+          partnerNickname: string;
+          channelRoomId: number;
+          hasResponeded: boolean;
+          partnerHasResponded: boolean;
+        };
+
+        if (hasResponeded || partnerHasResponded) return;
 
         useConfirmModalStore.getState().openModal({
           title: (
@@ -44,19 +58,84 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
           imageSrc: '/images/friends.png',
           variant: 'confirm',
           onConfirm: () => {
-            useWaitingModalStore.getState().openModal(partnerNickname);
-            // /api/v2/matching/acceptances 매칭 수락 api 연결
+            handleAccept(channelRoomId, partnerNickname);
+            useConfirmModalStore.getState().closeModal();
           },
           onCancel: () => {
+            handleReject(channelRoomId);
+            useConfirmModalStore.getState().closeModal();
             toast('매칭이 실패하였습니다', { icon: '🥺' });
-            // /api/v2/matching/rejections 매칭 거절 api 연결
           },
         });
+      },
+      'matching-success': (data: unknown) => {
+        const { partnerNickname } = data as {
+          channelRoomId: number;
+          partnerId: number;
+          partnerProfileImage: string;
+          partnerNickname: string;
+        };
+        toast(`${partnerNickname}님과 매칭을 성공했어요!`, { icon: '🥳' });
+      },
+      'matching-rejection': (data: unknown) => {
+        const { partnerNickname } = data as {
+          channelRoomId: number;
+          partnerId: number;
+          partnerProfileImage: string;
+          partnerNickname: string;
+        };
+        toast(`${partnerNickname}님과 매칭을 실패했어요`, { icon: '🥺' });
       },
     }),
 
     [],
   );
+
+  const handleAccept = async (channelRoomId: number, partnerNickname: string) => {
+    try {
+      const res = await postMatchingAccept({ channelRoomId });
+
+      switch (res.code) {
+        case 'MATCH_SUCCESS':
+          toast('매칭이 성사되었습니다!', { icon: '🥳' });
+          closeWaitingModal();
+          closeConfirmModal();
+
+          break;
+        case 'MATCH_PENDING':
+          toast('상대방의 응답을 기다리는 중입니다.');
+          closeConfirmModal();
+          openWaitingModal(partnerNickname);
+          break;
+        case 'MATCH_FAILED':
+          toast.error('상대방이 매칭을 거절했습니다.');
+          closeConfirmModal();
+          closeWaitingModal();
+          break;
+        case 'USER_DEACTIVATED':
+          toast.error('상대방이 탈퇴한 사용자입니다.');
+          break;
+        default:
+          toast.error('예상치 못한 응답입니다.');
+      }
+    } catch (e) {
+      toast.error('매칭 수락 중 오류가 발생했습니다.');
+    }
+  };
+
+  const handleReject = async (channelRoomId: number) => {
+    try {
+      const res = await postMatchingReject({ channelRoomId });
+
+      if (res.code === 'MATCH_REJECTION_SUCCESS') {
+        toast.success('매칭을 거절했습니다.');
+      } else {
+        toast.error('예상치 못한 응답입니다.');
+      }
+    } catch (e) {
+      toast.error('매칭 거절 중 오류가 발생했습니다.');
+    }
+  };
 
   useSSE({
     url: `${process.env.NEXT_PUBLIC_API_BASE_URL}/sse/subscribe`,

--- a/src/lib/api/matching.ts
+++ b/src/lib/api/matching.ts
@@ -1,3 +1,4 @@
+import { ChannelRoom } from './chat';
 import axiosInstance from '@lib/axios';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
@@ -56,5 +57,27 @@ export const postTuningSignal = async (
   payload: TuningSignalRequest,
 ): Promise<TuningSignalResponse> => {
   const response = await axiosInstance.post(`${BASE_URL}/v1/tuning/signal`, payload);
+  return response.data;
+};
+
+export interface MatchingRequest {
+  channelRoomId: number;
+}
+
+export interface MatchingResponse {
+  code: string;
+  message: string;
+  data: null;
+}
+
+// 수락 API
+export const postMatchingAccept = async (payload: MatchingRequest): Promise<MatchingResponse> => {
+  const response = await axiosInstance.post(`${BASE_URL}/v2/matching/acceptances`, payload);
+  return response.data;
+};
+
+// 거절 API
+export const postMatchingReject = async (payload: MatchingRequest): Promise<MatchingResponse> => {
+  const response = await axiosInstance.post(`${BASE_URL}/v2/matching/rejections`, payload);
   return response.data;
 };


### PR DESCRIPTION
### 🚀 연관된 이슈
- #79
<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
- 매칭 SSE 모달 - 수락 / 거절 api 연결
- `useParams` 사용으로 상대방 프로필 상세페이지 정상 표시되도록 수정
- 매칭 시 채팅방 내부 컴포넌트 색상 변경
- 채팅방 헤더 아이콘 삭제

<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     | 신규 기능 / 기능 개선 / UI 변경 등         |

### ✅ 테스트 목록

- [ ]
- [ ]

---

### 📎 참고 자료

<!-- 디자인 시안, 기획 문서, 관련 링크 등 참고할 만한 자료가 있다면 첨부해주세요
- [Figma 시안](https://figma.com/xyz)
- [기획 노션 문서](https://notion.so/project/abc) -->

---

### 📌 기타

<!-- 추가로 공유하고 싶은 내용이 있다면 자유롭게 작성해주세요
- 코드 리팩토링 대상이지만 현재는 기능 우선으로 구현했습니다 (추후 리팩토링 예정) -->

매칭 모달 안 닫히는 문제 트러블슈팅
일반관심사 / 공통관심사 분리 트러블슈팅 진행 예정
