### PR TITLE
공통 / 일반 관심사 분리 및 매칭되지 않은 사용자 키워드 블러 처리

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -81,6 +81,7 @@ export default function MyPage() {
               sameInterests={userInfo.sameInterests}
               normalInterests={userInfo.interests}
               nickname={userInfo.nickname}
+              relationType={userInfo.relationType}
             />
           </div>
         </div>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -78,7 +78,8 @@ export default function MyPage() {
             />
             <KeywordTagGroup
               keywords={userInfo.keywords}
-              sameInterests={userInfo.interests}
+              sameInterests={userInfo.sameInterests}
+              normalInterests={userInfo.interests}
               nickname={userInfo.nickname}
             />
           </div>

--- a/src/app/profile/[partnerId]/page.tsx
+++ b/src/app/profile/[partnerId]/page.tsx
@@ -50,6 +50,7 @@ export default function ProfileDetailPage() {
               normalInterests={userInfo.interests}
               sameInterests={userInfo.sameInterests}
               nickname={userInfo.nickname}
+              relationType={userInfo.relationType}
             />
           </div>
         </div>

--- a/src/app/profile/[partnerId]/page.tsx
+++ b/src/app/profile/[partnerId]/page.tsx
@@ -47,7 +47,8 @@ export default function ProfileDetailPage() {
             />
             <KeywordTagGroup
               keywords={userInfo.keywords}
-              sameInterests={userInfo.interests}
+              normalInterests={userInfo.interests}
+              sameInterests={userInfo.sameInterests}
               nickname={userInfo.nickname}
             />
           </div>

--- a/src/app/report/page.tsx
+++ b/src/app/report/page.tsx
@@ -39,8 +39,16 @@ export default function ReportPage() {
         </p>
         <div className="flex items-center gap-3 px-2">
           <button onClick={handleSortChange} className="flex items-center gap-1">
-            <p className="text-sm font-medium">{sortType === 'LATEST' ? '최신순' : '인기순'}</p>
-            <TbArrowsSort />
+            {reports.length
+              ? 0 && (
+                  <div>
+                    <p className="text-sm font-medium">
+                      {sortType === 'LATEST' ? '최신순' : '인기순'}
+                    </p>
+                    <TbArrowsSort />
+                  </div>
+                )
+              : []}
           </button>
         </div>
       </div>

--- a/src/components/common/KeywordTag.tsx
+++ b/src/components/common/KeywordTag.tsx
@@ -70,7 +70,7 @@ export default function KeywordTag({ keywords, variant = 'default' }: KeywordTag
             className={`inline-block rounded-full border px-3 py-1 text-xs font-medium ${
               isCommon
                 ? 'border-[var(--blue)] bg-[var(--light-blue)] text-[var(--dark-blue)]'
-                : 'border-[var(--gray-200)] text-black'
+                : 'border-[var(--gray-200)] bg-white text-black'
             }`}
           >
             # {displayLabel}

--- a/src/components/common/KeywordTag.tsx
+++ b/src/components/common/KeywordTag.tsx
@@ -62,7 +62,7 @@ export default function KeywordTag({ keywords, variant = 'default' }: KeywordTag
 
         const rawKeyword = keywordWithPrefix.split('_').slice(1).join('_');
         const isPreferredPeople = Object.keys(PreferredPeople).includes(rawKeyword);
-        const displayLabel = isPreferredPeople ? `👩🏻‍❤️‍👨🏻${label}` : label;
+        const displayLabel = isPreferredPeople ? `👩🏻‍❤️‍👨🏻 ${label}` : label;
 
         return (
           <div

--- a/src/components/matching/individual/KeywordTagGroup.tsx
+++ b/src/components/matching/individual/KeywordTagGroup.tsx
@@ -14,6 +14,7 @@ interface KeywordTagGroupProps {
   sameInterests?: TuningSameInterests;
   normalInterests?: TuningNormalInterests;
   nickname: string;
+  relationType?: string;
 }
 
 export default function KeywordTagGroup({
@@ -21,10 +22,12 @@ export default function KeywordTagGroup({
   sameInterests,
   normalInterests,
   nickname,
+  relationType,
 }: KeywordTagGroupProps) {
   const pathname = usePathname();
   const isProfilePage = pathname.startsWith('/mypage') || pathname.startsWith('/profile');
   const isMyPage = pathname.startsWith('/mypage');
+  const shouldBlurKeyword = relationType !== 'MATCHING';
 
   // 사용자 키워드를 렌더링용 문자열 배열로 변환 ('preferredPeople': 'RELIABLE' → 'PREFERRED_PEOPLE_RELIABLE')
   const keywordList = Object.entries(keywords).map(
@@ -77,8 +80,18 @@ export default function KeywordTagGroup({
         []
       )}
       {normalInterestList.length > 0 ? (
-        <div>
-          <KeywordTag keywords={normalInterestList} variant="default" />
+        <div className="relative">
+          {!isMyPage && shouldBlurKeyword && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center">
+              <div className="rounded-2xl border border-[var(--gray-400)] bg-white px-4 py-1 text-xs font-semibold text-[var(--gray-400)]">
+                매칭 관계가 되면 확인할 수 있어요
+              </div>
+            </div>
+          )}
+
+          <div className={!isMyPage && shouldBlurKeyword ? 'pointer-events-none blur-[3px]' : ''}>
+            <KeywordTag keywords={normalInterestList} variant="default" />
+          </div>
         </div>
       ) : (
         <p className="items-center justify-center text-sm font-light text-[var(--gray-300)]">

--- a/src/components/matching/individual/KeywordTagGroup.tsx
+++ b/src/components/matching/individual/KeywordTagGroup.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import KeywordTag from '@/components/common/KeywordTag';
-import { TuningKeywords, TuningSameInterests } from '@/lib/api/matching';
+import { TuningKeywords, TuningSameInterests, TuningNormalInterests } from '@/lib/api/matching';
 import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
 
 interface Tag {
   key: string;
@@ -10,26 +11,43 @@ interface Tag {
 }
 interface KeywordTagGroupProps {
   keywords: TuningKeywords;
-  sameInterests: TuningSameInterests;
+  sameInterests?: TuningSameInterests;
+  normalInterests?: TuningNormalInterests;
   nickname: string;
 }
 
 export default function KeywordTagGroup({
   keywords,
   sameInterests,
+  normalInterests,
   nickname,
 }: KeywordTagGroupProps) {
   const pathname = usePathname();
   const isProfilePage = pathname.startsWith('/mypage') || pathname.startsWith('/profile');
+  const isMyPage = pathname.startsWith('/mypage');
+
   // 사용자 키워드를 렌더링용 문자열 배열로 변환 ('preferredPeople': 'RELIABLE' → 'PREFERRED_PEOPLE_RELIABLE')
   const keywordList = Object.entries(keywords).map(
     ([category, key]) => `${category.toUpperCase()}_${key}`,
   );
 
-  const commonInterestList = Object.entries(sameInterests).flatMap(([category, keys]) => {
-    const normalizedCategory = normalizeCategory(category);
-    return keys.map((key: Tag) => `${normalizedCategory}_${key}`);
+  useEffect(() => {
+    console.log('sameInterests', sameInterests);
+    console.log('normalInterests', normalInterests);
   });
+  const commonInterestList = sameInterests
+    ? Object.entries(sameInterests).flatMap(([category, keys]) => {
+        const normalizedCategory = normalizeCategory(category);
+        return keys.map((key: string) => `${normalizedCategory}_${key}`);
+      })
+    : [];
+
+  const normalInterestList = normalInterests
+    ? Object.entries(normalInterests).flatMap(([category, keys]) => {
+        const normalizedCategory = normalizeCategory(category);
+        return keys.map((key: string) => `${normalizedCategory}_${key}`);
+      })
+    : [];
 
   //  camelCase → SNAKE_CASE 변환 유틸 함수'preferredPeople' → 'PREFERRED_PEOPLE'
   function normalizeCategory(category: string) {
@@ -42,17 +60,29 @@ export default function KeywordTagGroup({
         <p className="font-semibold">{nickname}님의 키워드에요</p>
         <KeywordTag keywords={keywordList} />
       </div>
-
       <div className="mb-4 space-y-1.5">
         <p className="font-semibold">
           {isProfilePage ? '선택한 모든 관심사를 보여드릴게요' : '함께 나누는 공통 관심사에요'}
         </p>
       </div>
       {commonInterestList.length > 0 ? (
-        <KeywordTag keywords={commonInterestList} variant="common" />
-      ) : (
+        <div>
+          <KeywordTag keywords={commonInterestList} variant="common" />
+        </div>
+      ) : !isMyPage ? (
         <p className="items-center justify-center text-sm font-light text-[var(--gray-300)]">
           공통 관심사가 존재하지 않습니다.
+        </p>
+      ) : (
+        []
+      )}
+      {normalInterestList.length > 0 ? (
+        <div>
+          <KeywordTag keywords={normalInterestList} variant="default" />
+        </div>
+      ) : (
+        <p className="items-center justify-center text-sm font-light text-[var(--gray-300)]">
+          일반 관심사가 존재하지 않습니다.
         </p>
       )}
     </main>

--- a/src/lib/api/matching.ts
+++ b/src/lib/api/matching.ts
@@ -21,6 +21,17 @@ export interface TuningSameInterests {
   hobbies: string[];
 }
 
+export interface TuningNormalInterests {
+  personality: string[];
+  preferredPeople: string[];
+  currentInterests: string[];
+  favoriteFoods: string[];
+  likedSports: string[];
+  pets: string[];
+  selfDevelopment: string[];
+  hobbies: string[];
+}
+
 export interface TuningUser {
   userId: number;
   profileImage: string;

--- a/src/lib/api/user.ts
+++ b/src/lib/api/user.ts
@@ -17,6 +17,16 @@ export interface GetUserInfoResponse {
       smoking: string;
       drinking: string;
     };
+    sameInterests: {
+      personality: string[];
+      preferredPeople: string[];
+      currentInterests: string[];
+      favoriteFoods: string[];
+      likedSports: string[];
+      pets: string[];
+      selfDevelopment: string[];
+      hobbies: string[];
+    };
     interests: {
       personality: string[];
       preferredPeople: string[];


### PR DESCRIPTION
### 🚀 연관된 이슈
- #87
<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
- 마이페이지 및 프로필 상세보기에서 공통 관심사와 일반 관심사가 분리되지 않는 문제 해결
- 매칭되지 않은 사용자의 일반 관심사 키워드 블러 처리 로직 추가

<img width="340" alt="image" src="https://github.com/user-attachments/assets/8b071a87-b2ad-4f94-927a-491ee39d0eba" />

<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     | 버그 수정 / UI 변경   |

### ✅ 테스트 목록

- [x] 매칭된 사용자의 키워드 전체 공개
- [x] 매칭되지 않은 사용자의 일반 키워드 부분 공개 (블러 처리)
