### PR TITLE
v1 QA 기반 수정사항 반영 및 매칭/채팅/알림 개선

### DIFF
--- a/src/app/alarm/page.tsx
+++ b/src/app/alarm/page.tsx
@@ -134,7 +134,7 @@ export default function AlarmPage() {
                     </div>
                   </div>
                 </AccordionTrigger>
-                <AccordionContent className="text-sm leading-6 whitespace-pre-wrap text-[var(--gray-300)]">
+                <AccordionContent className="text-wrap-keep text-sm leading-6 text-[var(--gray-300)]">
                   {alarm.content}
                 </AccordionContent>
               </AccordionItem>

--- a/src/app/chat/individual/[channelRoomId]/page.tsx
+++ b/src/app/chat/individual/[channelRoomId]/page.tsx
@@ -17,6 +17,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 import { formatKoreanDate } from '@/utils/format';
 import UnavailableChannelBanner from '@/components/chat/UnavailableChannelBanner';
+import { useWaitingModalStore } from '@/stores/modal/useWaitingModalStore';
 
 export default function ChatsIndividualPage() {
   const { channelRoomId } = useParams();
@@ -25,6 +26,12 @@ export default function ChatsIndividualPage() {
 
   const parsedChannelRoomId = Number(channelRoomId);
   const isChannelRoomIdValid = !!channelRoomId && !isNaN(parsedChannelRoomId);
+
+  const {
+    shouldShowModal,
+    channelRoomId: waitingModalChannelId,
+    openModal,
+  } = useWaitingModalStore();
 
   const { data, isLoading, fetchNextPage, hasNextPage } =
     useInfiniteQuery<ChannelRoomDetailResponse>({
@@ -58,6 +65,17 @@ export default function ChatsIndividualPage() {
       fetchNextPage();
     }
   }, [inView, hasNextPage, fetchNextPage]);
+
+  useEffect(() => {
+    if (
+      shouldShowModal &&
+      partner?.partnerNickname &&
+      waitingModalChannelId === parsedChannelRoomId &&
+      partner?.relationType !== 'MATCHING'
+    ) {
+      openModal(partner.partnerNickname, parsedChannelRoomId);
+    }
+  }, [shouldShowModal, partner?.partnerNickname, parsedChannelRoomId, waitingModalChannelId]);
 
   // polling
   useEffect(() => {

--- a/src/app/chat/individual/[channelRoomId]/page.tsx
+++ b/src/app/chat/individual/[channelRoomId]/page.tsx
@@ -102,7 +102,6 @@ export default function ChatsIndividualPage() {
             title={partner?.partnerNickname ?? ''}
             partnerId={partner?.partnerId}
             onLeave={() => console.log('나가기')}
-            onToggleDetail={() => console.log('상세 보기 토글')}
           />
         )}
         <div className="flex flex-col gap-6">

--- a/src/app/chat/individual/[channelRoomId]/page.tsx
+++ b/src/app/chat/individual/[channelRoomId]/page.tsx
@@ -97,11 +97,14 @@ export default function ChatsIndividualPage() {
   return (
     <>
       <main className="relative flex h-full w-full flex-col overflow-x-hidden px-6 pb-18">
-        <ChatHeader
-          title={partner?.partnerNickname ?? ''}
-          onLeave={() => console.log('나가기')}
-          onToggleDetail={() => console.log('상세 보기 토글')}
-        />
+        {typeof partner?.partnerId === 'number' && (
+          <ChatHeader
+            title={partner?.partnerNickname ?? ''}
+            partnerId={partner?.partnerId}
+            onLeave={() => console.log('나가기')}
+            onToggleDetail={() => console.log('상세 보기 토글')}
+          />
+        )}
         <div className="flex flex-col gap-6">
           {messages.map((msg, index) => {
             const currentDate = formatKoreanDate(msg.messageSendAt);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -160,3 +160,8 @@ body {
 .scrollbar-none::-webkit-scrollbar {
   display: none;
 }
+.text-wrap-keep {
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: keep-all;
+}

--- a/src/app/profile/[partnerId]/page.tsx
+++ b/src/app/profile/[partnerId]/page.tsx
@@ -35,7 +35,7 @@ export default function ProfileDetailPage() {
 
   return (
     <>
-      <Header title="프로필 상세보기" showBackButton={false} showNotificationButton={true} />
+      <Header title="프로필 상세보기" showBackButton={true} showNotificationButton={true} />
       <main className="pb-[calc(3.5rem + env(safe-area-inset-bottom))] flex-1 flex-col overflow-y-hidden px-4 pt-4">
         <div className="flex w-full flex-grow flex-col justify-between rounded-3xl px-5 py-4">
           <div className="space-y-4">

--- a/src/app/report/page.tsx
+++ b/src/app/report/page.tsx
@@ -33,14 +33,11 @@ export default function ReportPage() {
     <div className="bg-white px-8 py-4">
       <Header title="튜닝 리포트" showBackButton={false} showNotificationButton={true} />
 
-      <div className="mt-2 flex items-center justify-between">
-        <p className="px-2 font-bold">
-          {reports.length > 0 && dayjs(reports[0].createdDate).format('YYYY년 MM월 DD일')}
-        </p>
+      <div className="mt-2 flex items-center justify-end">
         <div className="flex items-center gap-3 px-2">
           <button onClick={handleSortChange} className="flex items-center gap-1">
             {reports.length > 0 ? (
-              <div>
+              <div className="flex items-center gap-1 whitespace-nowrap">
                 <p className="text-sm font-medium">{sortType === 'LATEST' ? '최신순' : '인기순'}</p>
                 <TbArrowsSort />
               </div>
@@ -57,44 +54,52 @@ export default function ReportPage() {
         <ReportLoading />
       ) : (
         reports.map((report) => (
-          <div key={report.reportId} className="mt-4 rounded-2xl border p-4">
-            <p className="mb-4 text-sm font-bold">
-              <mark className="bg-[var(--light-blue)]">{report.title}</mark>
+          <>
+            <p className="px-2 font-bold">
+              {reports.length > 0 && dayjs(report.createdDate).format('YYYY년 MM월 DD일')}
             </p>
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              components={{
-                h2: ({ node, ...props }) => (
-                  <h2 className="mt-4 mb-2 text-[0.85rem] font-bold text-gray-800" {...props} />
-                ),
-                h3: ({ node, ...props }) => (
-                  <h3 className="mt-3 text-[0.8rem] font-semibold text-gray-700" {...props} />
-                ),
-                strong: ({ node, ...props }) => (
-                  <strong className="text-[0.8rem] font-semibold text-black" {...props} />
-                ),
-                li: ({ node, ...props }) => (
-                  <li className="list-inside list-disc text-[0.8rem] leading-relaxed" {...props} />
-                ),
-                blockquote: ({ node, ...props }) => (
-                  <blockquote
-                    className="border-l-4 border-[var(--blue)] pl-4 text-[0.8rem] text-gray-600 italic"
-                    {...props}
-                  />
-                ),
-                p: ({ node, ...props }) => (
-                  <p className="my-1 text-[0.8rem] leading-relaxed text-gray-800" {...props} />
-                ),
-              }}
-            >
-              {report.content.replace(/\\n/g, '\n')}
-            </ReactMarkdown>
-            <ReactionGroup
-              reportId={report.reportId}
-              reactions={report.reactions}
-              myReactions={report.myReactions}
-            />
-          </div>
+            <div key={report.reportId} className="mt-4 mb-8 rounded-2xl border p-4">
+              <p className="mb-4 text-sm font-bold">
+                <mark className="bg-[var(--light-blue)]">{report.title}</mark>
+              </p>
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  h2: ({ node, ...props }) => (
+                    <h2 className="mt-4 mb-2 text-[0.85rem] font-bold text-gray-800" {...props} />
+                  ),
+                  h3: ({ node, ...props }) => (
+                    <h3 className="mt-3 text-[0.8rem] font-semibold text-gray-700" {...props} />
+                  ),
+                  strong: ({ node, ...props }) => (
+                    <strong className="text-[0.8rem] font-semibold text-black" {...props} />
+                  ),
+                  li: ({ node, ...props }) => (
+                    <li
+                      className="list-inside list-disc text-[0.8rem] leading-relaxed"
+                      {...props}
+                    />
+                  ),
+                  blockquote: ({ node, ...props }) => (
+                    <blockquote
+                      className="border-l-4 border-[var(--blue)] pl-4 text-[0.8rem] text-gray-600 italic"
+                      {...props}
+                    />
+                  ),
+                  p: ({ node, ...props }) => (
+                    <p className="my-1 text-[0.8rem] leading-relaxed text-gray-800" {...props} />
+                  ),
+                }}
+              >
+                {report.content.replace(/\\n/g, '\n')}
+              </ReactMarkdown>
+              <ReactionGroup
+                reportId={report.reportId}
+                reactions={report.reactions}
+                myReactions={report.myReactions}
+              />
+            </div>
+          </>
         ))
       )}
     </div>

--- a/src/app/report/page.tsx
+++ b/src/app/report/page.tsx
@@ -54,11 +54,11 @@ export default function ReportPage() {
         <ReportLoading />
       ) : (
         reports.map((report) => (
-          <>
+          <div key={report.reportId}>
             <p className="px-2 font-bold">
               {reports.length > 0 && dayjs(report.createdDate).format('YYYY년 MM월 DD일')}
             </p>
-            <div key={report.reportId} className="mt-4 mb-8 rounded-2xl border p-4">
+            <div className="mt-4 mb-8 rounded-2xl border p-4">
               <p className="mb-4 text-sm font-bold">
                 <mark className="bg-[var(--light-blue)]">{report.title}</mark>
               </p>
@@ -99,7 +99,7 @@ export default function ReportPage() {
                 myReactions={report.myReactions}
               />
             </div>
-          </>
+          </div>
         ))
       )}
     </div>

--- a/src/components/chat/UnavailableChannelBanner.tsx
+++ b/src/components/chat/UnavailableChannelBanner.tsx
@@ -1,7 +1,9 @@
 export default function UnavailableChannelBanner() {
   return (
     <div className="animate-fade-in absolute bottom-[55px] left-0 z-10 w-full max-w-[430px] bg-gradient-to-r from-[var(--blue)] to-[#a0c4ff] shadow-lg">
-      <p className="p-4 text-center text-sm font-semibold text-white">대화할 수 없는 채널입니다</p>
+      <p className="p-4 text-center text-sm font-semibold text-white">
+        매칭이 이루어지지 않아 채팅이 제한됩니다
+      </p>
     </div>
   );
 }

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -1,6 +1,5 @@
 import { useConfirmModalStore } from '@/stores/modal/useConfirmModalStore';
 import Image from 'next/image';
-import { IoClose } from 'react-icons/io5';
 
 export function ConfirmModal() {
   const {
@@ -33,9 +32,6 @@ export function ConfirmModal() {
   return isOpen ? (
     <div className="fixed inset-0 z-51 flex items-center justify-center bg-black/40">
       <div className="relative w-full max-w-xs space-y-4 rounded-2xl bg-white p-6 text-center">
-        <button onClick={handleCancel} className="absolute top-4 right-4">
-          <IoClose size={20} />
-        </button>
         {imageSrc && (
           <div className="flex w-full justify-center">
             <Image src={imageSrc} alt="friends Image" width={40} height={40} />

--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -4,7 +4,7 @@ export default function LoadingSpinner() {
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-8 py-10">
       <SyncLoader color="var(--blue)" size={8} />
-      <p className="text-sm">채널 정보를 불러오는 중이에요</p>
+      <p className="text-sm">데이터를 불러오는 중이에요</p>
     </div>
   );
 }

--- a/src/components/common/WaitingModal.tsx
+++ b/src/components/common/WaitingModal.tsx
@@ -6,8 +6,8 @@ export default function WaitingModal() {
   const partnerNickname = useWaitingModalStore((state) => state.partnerNickname);
 
   return isOpen ? (
-    <div className="fixed inset-0 z-51 flex items-center justify-center bg-black/40">
-      <div className="relative flex w-full max-w-xs flex-col items-center justify-center space-y-4 rounded-2xl bg-white p-6 text-center">
+    <div className="pointer-events-none fixed inset-0 z-51 flex items-center justify-center bg-black/40">
+      <div className="pointer-events-auto relative flex w-full max-w-xs flex-col items-center justify-center space-y-4 rounded-2xl bg-white p-6 text-center">
         <FadeLoader color="#84a7ff" height={10} width={3} margin={2} />
         <h2 className="text-base leading-relaxed font-semibold">
           {partnerNickname}님의 응답을

--- a/src/components/layout/ChatHeader.tsx
+++ b/src/components/layout/ChatHeader.tsx
@@ -6,12 +6,17 @@ import { LuLogOut } from 'react-icons/lu';
 
 interface ChatHeaderProps {
   title: string;
+  partnerId: number;
   onLeave: () => void;
   onToggleDetail?: () => void;
 }
 
-export default function ChatHeader({ title, onLeave, onToggleDetail }: ChatHeaderProps) {
+export default function ChatHeader({ title, partnerId, onLeave, onToggleDetail }: ChatHeaderProps) {
   const router = useRouter();
+
+  const handleNicknameClick = () => {
+    router.push(`/profile/${partnerId}`);
+  };
 
   return (
     <header className="fixed top-0 left-1/2 z-50 flex h-14 w-full max-w-[430px] -translate-x-1/2 items-center justify-between bg-white px-4">
@@ -23,7 +28,9 @@ export default function ChatHeader({ title, onLeave, onToggleDetail }: ChatHeade
         onClick={onToggleDetail}
         className="flex max-w-[220px] flex-1 cursor-pointer items-center justify-center gap-2 overflow-hidden text-lg font-bold whitespace-nowrap text-black"
       >
-        <span className="overflow-hidden text-ellipsis">{title}</span>
+        <span onClick={handleNicknameClick} className="overflow-hidden text-ellipsis">
+          {title}
+        </span>
         {/* <FaAngleDown className="ml-1 flex-shrink-0 text-[clamp(1rem,2vw,0.8rem)]" /> */}
       </div>
 

--- a/src/components/layout/ChatHeader.tsx
+++ b/src/components/layout/ChatHeader.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useWaitingModalStore } from '@/stores/modal/useWaitingModalStore';
 import { useRouter } from 'next/navigation';
 import { FaAngleLeft, FaAngleDown } from 'react-icons/fa6';
 import { LuLogOut } from 'react-icons/lu';
@@ -12,15 +13,20 @@ interface ChatHeaderProps {
 
 export default function ChatHeader({ title, partnerId, onLeave }: ChatHeaderProps) {
   const router = useRouter();
+  const closeModal = useWaitingModalStore((state) => state.closeModal);
 
   const handleNicknameClick = () => {
     router.push(`/profile/${partnerId}`);
   };
 
+  const handleBack = () => {
+    closeModal();
+    router.back();
+  };
   return (
     <header className="fixed top-0 left-1/2 z-50 flex h-14 w-full max-w-[430px] -translate-x-1/2 items-center justify-between bg-white px-4">
-      <button onClick={() => router.back()} className="flex w-6 items-center justify-center p-1">
-        <FaAngleLeft className="text-[clamp(1rem,2vw,1.2rem)]" />
+      <button onClick={handleBack} className="flex w-6 items-center justify-center p-1">
+        <FaAngleLeft className="z-[100] text-[clamp(1rem,2vw,1.2rem)]" />
       </button>
 
       <div

--- a/src/components/layout/ChatHeader.tsx
+++ b/src/components/layout/ChatHeader.tsx
@@ -8,10 +8,9 @@ interface ChatHeaderProps {
   title: string;
   partnerId: number;
   onLeave: () => void;
-  onToggleDetail?: () => void;
 }
 
-export default function ChatHeader({ title, partnerId, onLeave, onToggleDetail }: ChatHeaderProps) {
+export default function ChatHeader({ title, partnerId, onLeave }: ChatHeaderProps) {
   const router = useRouter();
 
   const handleNicknameClick = () => {
@@ -25,13 +24,11 @@ export default function ChatHeader({ title, partnerId, onLeave, onToggleDetail }
       </button>
 
       <div
-        onClick={onToggleDetail}
+        onClick={handleNicknameClick}
         className="flex max-w-[220px] flex-1 cursor-pointer items-center justify-center gap-2 overflow-hidden text-lg font-bold whitespace-nowrap text-black"
       >
-        <span onClick={handleNicknameClick} className="overflow-hidden text-ellipsis">
-          {title}
-        </span>
-        {/* <FaAngleDown className="ml-1 flex-shrink-0 text-[clamp(1rem,2vw,0.8rem)]" /> */}
+        <span className="overflow-hidden text-ellipsis">{title}</span>
+        <FaAngleDown className="ml-1 flex-shrink-0 text-[clamp(1rem,2vw,0.8rem)]" />
       </div>
 
       <button onClick={onLeave} className="flex w-8 items-center justify-center p-1">

--- a/src/components/layout/ClientLayoutContent.tsx
+++ b/src/components/layout/ClientLayoutContent.tsx
@@ -91,12 +91,13 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
           partnerProfileImage: string;
           partnerNickname: string;
         };
-        if (currentWaitingChannelIdRef.current !== channelRoomId) return;
+        if (!channelRoomId) return;
 
         currentWaitingChannelIdRef.current = null;
         closeWaitingModal();
+        useWaitingModalStore.getState().reset();
 
-        toast(`${partnerNickname}님과 매칭을 성공했어요!`, { icon: '🥳' });
+        toast(`${partnerNickname}님과 매칭을 성공했어요!`, { icon: '🥳', duration: 4000 });
       },
       'matching-rejection': (data: unknown) => {
         const { channelRoomId, partnerNickname } = data as {
@@ -113,7 +114,7 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
           closeConfirmModal();
         }
 
-        toast(`${partnerNickname}님과 매칭을 실패했어요`, { icon: '🥺' });
+        toast(`${partnerNickname}님과 매칭을 실패했어요`, { icon: '🥺', duration: 4000 });
       },
     }),
 
@@ -126,7 +127,7 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
 
       switch (res.code) {
         case 'MATCH_SUCCESS':
-          toast('매칭이 성사되었습니다!', { icon: '🥳' });
+          toast('매칭이 성사되었습니다!', { icon: '🥳', duration: 4000 });
           closeWaitingModal();
           closeConfirmModal();
 
@@ -134,7 +135,7 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
         case 'MATCH_PENDING':
           toast('상대방의 응답을 기다리는 중입니다');
           closeConfirmModal();
-          openWaitingModal(partnerNickname);
+          openWaitingModal(partnerNickname, channelRoomId);
           currentWaitingChannelIdRef.current = channelRoomId;
           break;
         case 'MATCH_FAILED':

--- a/src/components/layout/ClientLayoutContent.tsx
+++ b/src/components/layout/ClientLayoutContent.tsx
@@ -73,7 +73,6 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
             handleAccept(channelRoomId, partnerNickname);
             closeConfirmModal();
             closeWaitingModal();
-            // lastOpenedRoomIdRef.current = null;
             lastOpenedPartnerRef.current = null;
           },
           onCancel: () => {

--- a/src/components/matching/individual/KeywordTagGroup.tsx
+++ b/src/components/matching/individual/KeywordTagGroup.tsx
@@ -27,6 +27,7 @@ export default function KeywordTagGroup({
   const pathname = usePathname();
   const isProfilePage = pathname.startsWith('/mypage') || pathname.startsWith('/profile');
   const isMyPage = pathname.startsWith('/mypage');
+  const isMatchingPage = pathname.startsWith('/matching');
   const shouldBlurKeyword = relationType !== 'MATCHING';
 
   // 사용자 키워드를 렌더링용 문자열 배열로 변환 ('preferredPeople': 'RELIABLE' → 'PREFERRED_PEOPLE_RELIABLE')
@@ -95,7 +96,7 @@ export default function KeywordTagGroup({
         </div>
       ) : (
         <p className="items-center justify-center text-sm font-light text-[var(--gray-300)]">
-          일반 관심사가 존재하지 않습니다.
+          {!isMatchingPage ? '일반 관심사가 존재하지 않습니다.' : ''}
         </p>
       )}
     </main>

--- a/src/stores/modal/useWaitingModalStore.ts
+++ b/src/stores/modal/useWaitingModalStore.ts
@@ -1,15 +1,48 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 interface WaitingModalState {
   isOpen: boolean;
+  shouldShowModal: boolean;
   partnerNickname: string;
-  openModal: (nickname: string) => void;
+  channelRoomId: number | null;
+  openModal: (nickname: string, channelRoomId: number) => void;
   closeModal: () => void;
+  reset: () => void;
 }
 
-export const useWaitingModalStore = create<WaitingModalState>((set) => ({
-  isOpen: false,
-  partnerNickname: '',
-  openModal: (nickname) => set({ isOpen: true, partnerNickname: nickname }),
-  closeModal: () => set({ isOpen: false, partnerNickname: '' }),
-}));
+export const useWaitingModalStore = create<WaitingModalState>()(
+  persist(
+    (set) => ({
+      isOpen: false,
+      shouldShowModal: false,
+      partnerNickname: '',
+      channelRoomId: null,
+
+      openModal: (nickname, channelRoomId) =>
+        set({
+          isOpen: true,
+          shouldShowModal: true,
+          partnerNickname: nickname,
+          channelRoomId,
+        }),
+
+      closeModal: () =>
+        set((state) => ({
+          ...state,
+          isOpen: false,
+        })),
+
+      reset: () =>
+        set({
+          isOpen: false,
+          shouldShowModal: false,
+          partnerNickname: '',
+          channelRoomId: null,
+        }),
+    }),
+    {
+      name: 'waiting-modal-storage',
+    },
+  ),
+);


### PR DESCRIPTION
### 🚀 연관된 이슈
- #91
<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
- 채팅방 헤더 닉네임 클릭 시 상세정보 페이지로 이동
- 프로필 상세보기 뒤로가기 버튼 추가
- 공통 로딩 컴포넌트로 사용하기 위한 범용적 문구 수정
- 튜닝 페이지에서 일반 관심사 관련 문구 숨김 처리
- 튜닝 리포트마다 각각 날짜가 뜨지 않는 문제 수정
- `ConfirmModal` 닫기 버튼 제거
- 채팅방 헤더 화살표 클릭 시 상세페이지 이동 기능 활성화
- 매칭 토스트 메시지 노출 시간 1000ms → 4000ms로 수정
- 매칭 응답 대기 중 모달이 떠 있는 상태에서도 채팅방에서 정상적으로 나갈 수 있도록 로직 수정
- 매칭 실패 시 안내 문구를 중립적인 표현으로 수정
- 알림 단어 단위 줄바꿈을 위한 `text-wrap-keep` 유틸 클래스 추가
- 매칭 결정 알림 SSE 연결

<img width="325" alt="alarm-keep" src="https://github.com/user-attachments/assets/5fdeda3d-73be-4349-a0b2-4e47a20b0f80" />
<img width="335" alt="alarm-keep" src="https://github.com/user-attachments/assets/d70e0011-b8a4-4390-a03d-c8d15d182d50" />

<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     | 신규 기능 / 기능 개선 / 버그 수정 / UI 변경   |
