### PR TITLE
SSE 버그 수정 및 QA 피드백 기반 예외 처리 개선

### DIFF
--- a/src/app/chat/individual/[channelRoomId]/page.tsx
+++ b/src/app/chat/individual/[channelRoomId]/page.tsx
@@ -40,7 +40,7 @@ export default function ChatsIndividualPage() {
   const handleLeaveChatRoom = (channelRoomId: number, partnerNickname: string) => {
     useConfirmModalStore.getState().openModal({
       title: '정말 채팅방을 나가시겠어요?',
-      description: '채널을 나가면 이전 채팅 기록을\n 다시 확인할 수 없어요.',
+      description: '채널을 나가면 메시지를 다시 확인할 수 없으며,\n상대와의 채팅이 종료됩니다',
       confirmText: '나가기',
       cancelText: '취소',
       variant: 'confirm',

--- a/src/app/chat/individual/[channelRoomId]/page.tsx
+++ b/src/app/chat/individual/[channelRoomId]/page.tsx
@@ -20,6 +20,7 @@ import { formatKoreanDate } from '@/utils/format';
 import UnavailableChannelBanner from '@/components/chat/UnavailableChannelBanner';
 import { useWaitingModalStore } from '@/stores/modal/useWaitingModalStore';
 import { useConfirmModalStore } from '@/stores/modal/useConfirmModalStore';
+import { useMatchingResponseStore } from '@/stores/modal/useMatchingResponseStore';
 
 export default function ChatsIndividualPage() {
   const { channelRoomId } = useParams();
@@ -88,6 +89,9 @@ export default function ChatsIndividualPage() {
   const partner = data?.pages?.[0]?.data;
   const messages = data?.pages.flatMap((page) => page.data.messages.list) || [];
 
+  const hasResponded = useMatchingResponseStore((state) => state.hasResponded);
+  const isUnmatched = partner?.relationType === 'UNMATCHED' && hasResponded;
+
   useEffect(() => {
     if (inView && hasNextPage) {
       fetchNextPage();
@@ -137,8 +141,6 @@ export default function ChatsIndividualPage() {
     );
   if (isLoading)
     return <p className="flex items-center justify-center text-sm font-medium">로딩 중...</p>;
-
-  const isUnmatched = partner?.relationType === 'UNMATCHED';
 
   return (
     <>

--- a/src/components/common/NewMessageToast.tsx
+++ b/src/components/common/NewMessageToast.tsx
@@ -7,7 +7,8 @@ import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 
 export default function NewMessageToast() {
-  const { toast, hideToast } = useNewMessageStore();
+  const { hideToast } = useNewMessageStore();
+  const toast = useNewMessageStore((state) => state.toast);
   const router = useRouter();
 
   useEffect(() => {

--- a/src/components/common/NewMessageToast.tsx
+++ b/src/components/common/NewMessageToast.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useNewMessageStore } from '@/stores/modal/useNewMessageStore';
 import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -10,6 +10,10 @@ export default function NewMessageToast() {
   const { hideToast } = useNewMessageStore();
   const toast = useNewMessageStore((state) => state.toast);
   const router = useRouter();
+  const pathname = usePathname();
+  const currentRoomId = pathname?.startsWith('/chat/individual/')
+    ? Number(pathname.split('/')[3]?.split('?')[0])
+    : null;
 
   useEffect(() => {
     if (toast) {
@@ -20,7 +24,7 @@ export default function NewMessageToast() {
     }
   }, [toast]);
 
-  if (!toast) return null;
+  if (!toast || currentRoomId === toast.channelRoomId) return null;
 
   const handleClick = () => {
     router.push(`/chat/individual/${toast.channelRoomId}?page=0&size=0`);

--- a/src/components/layout/ClientLayoutContent.tsx
+++ b/src/components/layout/ClientLayoutContent.tsx
@@ -18,6 +18,7 @@ import NewMessageToast from '../common/NewMessageToast';
 import { useNewMessageStore } from '@/stores/modal/useNewMessageStore';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@/lib/queryClient';
+import { useMatchingResponseStore } from '@/stores/modal/useMatchingResponseStore';
 
 const EXCLUDE_PATHS = ['/login', '/onboarding', '/not-found'];
 const HEADER_HEIGHT = 56;
@@ -34,7 +35,7 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
   const lastOpenedRoomIdRef = useRef<number | null>(null);
   const currentWaitingChannelIdRef = useRef<number | null>(null);
   const lastOpenedPartnerRef = useRef<string | null>(null);
-
+  const setHasResponded = useMatchingResponseStore((state) => state.setHasResponded);
   const shouldConnectSSE = useMemo(() => {
     return !EXCLUDE_PATHS.some((excludedPath) => pathname?.startsWith(excludedPath));
   }, [pathname]);
@@ -239,7 +240,7 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
   const handleAccept = async (channelRoomId: number, partnerNickname: string) => {
     try {
       const res = await postMatchingAccept({ channelRoomId });
-
+      setHasResponded(true);
       switch (res.code) {
         case 'MATCH_SUCCESS':
           toast('매칭이 성사되었습니다!', { icon: '🥳', duration: 4000 });
@@ -281,6 +282,7 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
 
   const handleReject = async (channelRoomId: number) => {
     try {
+      setHasResponded(true);
       const res = await postMatchingReject({ channelRoomId });
 
       if (res.code === 'MATCH_REJECTION_SUCCESS') {

--- a/src/components/layout/ClientLayoutContent.tsx
+++ b/src/components/layout/ClientLayoutContent.tsx
@@ -77,12 +77,14 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
           imageSrc: '/images/friends.png',
           variant: 'confirm',
           onConfirm: () => {
+            useMatchingResponseStore.getState().setHasResponded(true);
             handleAccept(channelRoomId, partnerNickname);
             closeConfirmModal();
             closeWaitingModal();
             lastOpenedPartnerRef.current = null;
           },
           onCancel: () => {
+            useMatchingResponseStore.getState().setHasResponded(true);
             handleReject(channelRoomId);
             closeConfirmModal();
             closeWaitingModal();
@@ -117,6 +119,7 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
         if (currentWaitingChannelIdRef.current !== channelRoomId) return;
         if (currentWaitingChannelIdRef.current === channelRoomId) {
           currentWaitingChannelIdRef.current = null;
+          useMatchingResponseStore.getState().setHasResponded(true);
           closeWaitingModal();
           closeConfirmModal();
         }
@@ -130,6 +133,9 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
           partnerProfileImage: string;
           partnerNickname: string;
         };
+
+        const hasResponded = useMatchingResponseStore.getState().hasResponded;
+        if (hasResponded) return;
 
         try {
           const res = await getChannelRoomDetail(channelRoomId);
@@ -240,7 +246,6 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
   const handleAccept = async (channelRoomId: number, partnerNickname: string) => {
     try {
       const res = await postMatchingAccept({ channelRoomId });
-      setHasResponded(true);
       switch (res.code) {
         case 'MATCH_SUCCESS':
           toast('매칭이 성사되었습니다!', { icon: '🥳', duration: 4000 });
@@ -282,7 +287,6 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
 
   const handleReject = async (channelRoomId: number) => {
     try {
-      setHasResponded(true);
       const res = await postMatchingReject({ channelRoomId });
 
       if (res.code === 'MATCH_REJECTION_SUCCESS') {

--- a/src/components/layout/ClientLayoutContent.tsx
+++ b/src/components/layout/ClientLayoutContent.tsx
@@ -36,9 +36,8 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
   const currentWaitingChannelIdRef = useRef<number | null>(null);
   const lastOpenedPartnerRef = useRef<string | null>(null);
   const setHasResponded = useMatchingResponseStore((state) => state.setHasResponded);
-  const shouldConnectSSE = useMemo(() => {
-    return !EXCLUDE_PATHS.some((excludedPath) => pathname?.startsWith(excludedPath));
-  }, [pathname]);
+  const shouldConnectSSE =
+    pathname && !EXCLUDE_PATHS.some((excludedPath) => pathname.startsWith(excludedPath));
 
   const sseHandlers = useMemo(
     () => ({
@@ -232,12 +231,12 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
     [],
   );
 
+  const isPathValid = typeof pathname === 'string' && pathname.length > 0;
   useSSE({
     url: `${process.env.NEXT_PUBLIC_API_BASE_URL}/sse/subscribe`,
     handlers: sseHandlers,
-    enabled: shouldConnectSSE,
+    enabled: Boolean(isPathValid && shouldConnectSSE),
   });
-
   useEffect(() => {
     setMounted(true);
     setIsHiddenUI(EXCLUDE_PATHS.some((route) => pathname.startsWith(route)));

--- a/src/components/onboarding/information/UserInformationForm.tsx
+++ b/src/components/onboarding/information/UserInformationForm.tsx
@@ -56,6 +56,11 @@ export default function UserInformationForm({ providerId }: UserInformationFormP
       const axiosError = error as AxiosError<{ code?: string }>;
       const code = axiosError.response?.data?.code;
 
+      if (code === 'DUPLICATE_USER') {
+        toast.error('이미 등록된 사용자입니다. 다시 로그인해주세요.');
+        router.replace('/login');
+      }
+
       if (code === 'DUPLICATE_NICKNAME') {
         toast.error('이미 사용중인 닉네임입니다. 다시 선택해주세요.');
         return;

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -7,7 +7,15 @@ type SSEEventHandlers = {
   [eventName: string]: (data: unknown) => void;
 };
 
-export const useSSE = ({ url, handlers }: { url: string; handlers: SSEEventHandlers }) => {
+export const useSSE = ({
+  url,
+  handlers,
+  enabled = true,
+}: {
+  url: string;
+  handlers: SSEEventHandlers;
+  enabled?: boolean;
+}) => {
   const retryTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isConnectingRef = useRef(false);
   const handlersRef = useRef(handlers);
@@ -19,6 +27,7 @@ export const useSSE = ({ url, handlers }: { url: string; handlers: SSEEventHandl
   }, [handlers]);
 
   useEffect(() => {
+    if (!enabled) return;
     let eventSource: EventSource | null = null;
 
     const connect = () => {
@@ -82,5 +91,5 @@ export const useSSE = ({ url, handlers }: { url: string; handlers: SSEEventHandl
       }
       if (retryTimeoutRef.current) clearTimeout(retryTimeoutRef.current);
     };
-  }, [url]);
+  }, [url, enabled]);
 };

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -1,6 +1,5 @@
 'use client';
 
-import { useNewMessageStore } from '@/stores/modal/useNewMessageStore';
 import { useEffect, useRef } from 'react';
 
 type SSEEventHandlers = {
@@ -20,7 +19,6 @@ export const useSSE = ({
   const isConnectingRef = useRef(false);
   const handlersRef = useRef(handlers);
   const listenerMapRef = useRef<Record<string, (e: MessageEvent) => void>>({});
-  const showToast = useNewMessageStore((state) => state.showToast);
 
   useEffect(() => {
     handlersRef.current = handlers;

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -68,8 +68,14 @@ export const useSSE = ({
             console.error(`Error parsing SSE event '${event}':`, err);
           }
         };
-        listenerMapRef.current[event] = listener;
-        eventSource!.addEventListener(event, listener);
+        if (eventSource) {
+          if (listenerMapRef.current[event]) {
+            eventSource.removeEventListener(event, listenerMapRef.current[event]!);
+          }
+
+          listenerMapRef.current[event] = listener;
+          eventSource.addEventListener(event, listener);
+        }
       });
 
       eventSource.onerror = (err: Event) => {
@@ -106,5 +112,5 @@ export const useSSE = ({
       if (retryTimeoutRef.current) clearTimeout(retryTimeoutRef.current);
       clearInterval(heartbeatInterval);
     };
-  }, [url, enabled]);
+  }, [url, enabled, handlers]);
 };

--- a/src/lib/schema/onboardingValidation.ts
+++ b/src/lib/schema/onboardingValidation.ts
@@ -15,7 +15,10 @@ export const registerUserSchema = z.object({
   oneLineIntroduction: z
     .string()
     .min(10, { message: '최소 10자 이상 작성해주세요.' })
-    .max(100, { message: '최대 100자까지만 작성할 수 있어요.' }),
+    .max(100, { message: '최대 100자까지만 작성할 수 있어요.' })
+    .refine((value) => value.replace(/\s/g, '').length >= 10, {
+      message: '최소 10자 이상 작성해주세요.',
+    }),
   isTest: z.boolean(),
 });
 

--- a/src/stores/modal/useMatchingResponseStore.ts
+++ b/src/stores/modal/useMatchingResponseStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface MatchingResponseStore {
+  hasResponded: boolean;
+  setHasResponded: (value: boolean) => void;
+}
+
+export const useMatchingResponseStore = create<MatchingResponseStore>((set) => ({
+  hasResponded: false,
+  setHasResponded: (value) => set({ hasResponded: value }),
+}));


### PR DESCRIPTION
### 🚀 연관된 이슈
- #103
<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
**버그 수정**
- 새 메세지 수신 팝업이 표시되지 않던 문제 해결
- `ConfirmModal` 응답 이전에는 `UnavailableChannelBanner`가 표시되지 않도록 수정
- 매칭 거절 시 SSE 모달과 거절 배너가 동시에 노출되는 문제 수정
- `useMemo` 제거로 `eventSource` 연결 안 되는 이슈 해결

**기능 개선**
- 채팅방 나가기 모달 문구 수정

**예외 처리**
- 로그인 / 온보딩 페이지에서 SSE 호출 방지
- 온보딩 한줄소개 zod 스키마 최소 10자 검증 시 공백 제외하도록 수정
- 현재 접속 중인 채팅방에서는 새 메세지 토스트가 표시되지 않도록 예외 처리 로직 추가
- 온보딩 중 등록된 사용자일 때 409 상태 코드 감지하는 로직 추가
- SSE 연결 중 `heartbeat` 상태 감지 로직 추가

<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     | 기능 개선 / 버그 수정 / UI 변경     |