### PR TITLE
나간 채팅방 및 비로그인 유저 접근 예외 처리 및 `AuthGuard` 적용

### DIFF
--- a/src/app/alarm/page.tsx
+++ b/src/app/alarm/page.tsx
@@ -16,8 +16,8 @@ import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { getAlarmList } from '@/lib/api/alarm';
 import { useEffect } from 'react';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
-import ChatRoomNotFoundPage from '@/components/chat/ChatRoomNotFound';
 import AlarmListNotFoundPage from '@/components/alarm/AlarmListNotFound';
+import toast from 'react-hot-toast';
 
 dayjs.extend(relativeTime);
 dayjs.locale('ko');
@@ -92,7 +92,12 @@ export default function AlarmPage() {
               return (
                 <div
                   key={index}
-                  onClick={() => router.push(`/chat/individual/${roomId}?page=0&size=20`)}
+                  onClick={() => {
+                    if (!roomId) {
+                      toast.error('이미 나간 채팅방입니다.');
+                    }
+                    router.push(`/chat/individual/${roomId}?page=0&size=20`);
+                  }}
                   className="cursor-pointer rounded-xl border-b bg-white px-4 py-2 transition hover:bg-gray-50"
                 >
                   <div className="mt-1 mb-1 flex items-center justify-between">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import localFont from 'next/font/local';
 import { Toaster } from 'react-hot-toast';
 import ClientLayoutContent from '@/components/layout/ClientLayoutContent';
 import Providers from './providers';
+import { AuthGuard } from '@/components/layout/AuthGuard';
 
 const pretendard = localFont({
   src: '../fonts/PretendardVariable.woff2',
@@ -33,9 +34,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       >
         <Providers>
           <ClientLayoutContent>
-            <div className="mx-auto flex h-[calc(screen-32px)] w-full max-w-md flex-col bg-white">
-              {children}
-            </div>
+            <AuthGuard>
+              <div className="mx-auto flex h-[calc(screen-32px)] w-full max-w-md flex-col bg-white">
+                {children}
+              </div>
+            </AuthGuard>
           </ClientLayoutContent>
         </Providers>
         <Toaster />

--- a/src/components/layout/AuthGuard.tsx
+++ b/src/components/layout/AuthGuard.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { isAuthenticated } from '@/utils/auth';
+
+const PUBLIC_PATHS = ['/login', '/signup', '/terms'];
+
+export const AuthGuard = ({ children }: { children: React.ReactNode }) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [canRender, setCanRender] = useState(false);
+
+  useEffect(() => {
+    const isPublic = PUBLIC_PATHS.includes(pathname);
+
+    if (isPublic) {
+      setCanRender(true);
+      return;
+    }
+
+    if (!isAuthenticated()) {
+      router.replace('/login');
+    } else {
+      setCanRender(true);
+    }
+  }, [pathname, router]);
+
+  if (!canRender) return null;
+
+  return <>{children}</>;
+};

--- a/src/components/layout/AuthGuard.tsx
+++ b/src/components/layout/AuthGuard.tsx
@@ -4,7 +4,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { isAuthenticated } from '@/utils/auth';
 
-const PUBLIC_PATHS = ['/login', '/signup', '/terms'];
+const PUBLIC_PATH_PREFIXES = ['/login', '/onboarding', '/not-found'];
 
 export const AuthGuard = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter();
@@ -12,7 +12,7 @@ export const AuthGuard = ({ children }: { children: React.ReactNode }) => {
   const [canRender, setCanRender] = useState(false);
 
   useEffect(() => {
-    const isPublic = PUBLIC_PATHS.includes(pathname);
+    const isPublic = PUBLIC_PATH_PREFIXES.some((publicPath) => pathname.startsWith(publicPath));
 
     if (isPublic) {
       setCanRender(true);

--- a/src/lib/api/chat.ts
+++ b/src/lib/api/chat.ts
@@ -65,10 +65,23 @@ export const getChannelRoomDetail = async (
   page = 0,
   size = 10,
 ): Promise<ChannelRoomDetailResponse> => {
-  const response = await axiosInstance.get(
-    `/v1/channel-rooms/${channelRoomId}?page=${page}&size=${size}`,
-  );
-  return response.data;
+  try {
+    const response = await axiosInstance.get(
+      `/v1/channel-rooms/${channelRoomId}?page=${page}&size=${size}`,
+    );
+    return response.data;
+  } catch (error: any) {
+    const code = error?.response?.data?.code;
+
+    if (code === 'ALREADY_EXITED_CHANNEL_ROOM') {
+      throw new Error('ALREADY_EXITED_CHANNEL_ROOM');
+    }
+    if (code === 'USER_DEACTIVATED') {
+      throw new Error('USER_DEACTIVATED');
+    }
+
+    throw new Error('UNKNOWN_CHANNEL_ROOM_ERROR');
+  }
 };
 
 export interface PostChannelMessageRequest {


### PR DESCRIPTION
### 🚀 연관된 이슈
- #103
<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
- 이미 나간 채팅방을 알림 페이지에서 접속했을 때 예외 처리
- 브라우저 뒤로가기로 나간 채팅방에 접근했을 때 예외 처리 추가
- AuthGuard 추가 및 로그인 상태 유지 기능 구현

---

- 로그인하지 않은 유저가 브라우저 url로 다른 페이지에 접근할 수 없게 예외처리

https://github.com/user-attachments/assets/b0727b4b-3851-44d2-8e83-b719d2c474b4


<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     | 기능 개선 / 버그 수정 |
