### PR TITLE
Refresh Token 만료 시 무한 요청 방지를 위한 예외 처리 추가

### DIFF
--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -34,13 +34,25 @@ export const reissueAccessToken = async (): Promise<AccessTokenReissueResponse> 
   console.log('🔁 Token reissue 요청 보냄');
   axios.defaults.withCredentials = true;
 
-  const response = await axios.post<AccessTokenReissueResponse>(
-    `${BASE_URL}/v1/auth/token`,
-    {},
-    { withCredentials: true },
-  );
+  try {
+    const response = await axios.post<AccessTokenReissueResponse>(
+      `${BASE_URL}/v1/auth/token`,
+      {},
+      { withCredentials: true },
+    );
 
-  return response.data;
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const code = error.response?.data?.code;
+      if (code === 'REFRESH_TOKEN_INVALID') {
+        console.warn('❌ RefreshToken이 유효하지 않음');
+        window.location.href = '/login';
+      }
+    }
+
+    throw error;
+  }
 };
 
 interface DeleteLogoutResponse {


### PR DESCRIPTION
### 🚀 연관된 이슈
- #113
<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
- Access Token 재발급 API인 `/api/v1/auth/token`에서 넘겨주는 400 에러에 대한 예외 처리 진행
<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     | 기능 개선  |
