### PR TITLE
`REFRESH_TOKEN_INVALID` 응답 시 무한 리다이렉트 이슈 해결 - 만료된 RT로 인한 자동 로그인 루프 방지

### DIFF
--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -34,13 +34,25 @@ export const reissueAccessToken = async (): Promise<AccessTokenReissueResponse> 
   console.log('🔁 Token reissue 요청 보냄');
   axios.defaults.withCredentials = true;
 
-  const response = await axios.post<AccessTokenReissueResponse>(
-    `${BASE_URL}/v1/auth/token`,
-    {},
-    { withCredentials: true },
-  );
+  try {
+    const response = await axios.post<AccessTokenReissueResponse>(
+      `${BASE_URL}/v1/auth/token`,
+      {},
+      { withCredentials: true },
+    );
 
-  return response.data;
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const code = error.response?.data?.code;
+      if (code === 'REFRESH_TOKEN_INVALID') {
+        console.warn('❌ RefreshToken이 유효하지 않음');
+        window.location.href = '/login';
+      }
+    }
+
+    throw error;
+  }
 };
 
 interface DeleteLogoutResponse {

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -47,6 +47,7 @@ export const reissueAccessToken = async (): Promise<AccessTokenReissueResponse> 
       const code = error.response?.data?.code;
       if (code === 'REFRESH_TOKEN_INVALID') {
         console.warn('❌ RefreshToken이 유효하지 않음');
+        localStorage.setItem('hasLoggedIn', 'false');
         window.location.href = '/login';
       }
     }


### PR DESCRIPTION
### 🚀 연관된 이슈
- #113
<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
- Access Token 재발급 API(`/api/v1/auth/token`)에서 발생하는 400 `REFRESH_TOKEN_INVALID` 에러에 대한 예외 처리 로직 추가
- 해당 에러 발생 시 `hasLoggedIn` 값을 false로 설정하여 자동 로그인 조건을 해제
- 로그인 페이지 진입 시 불필요한 자동 로그인 시도를 차단하여 무한 리다이렉트 루프 방지


<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     | 버그 수정  |
| 문제 원인   | 만료된 Refresh Token으로 인한 재발급 실패 후, 자동 로그인 로직이 반복 실행됨  |
| 해결 방법     | `REFRESH_TOKEN_INVALID` 수신 시 `localStorage`에서 `hasLoggedIn`을 false로 설정하여 자동 로그인 비활성화  |

---

- https://github.com/100-hours-a-week/2-hertz-wiki/issues/390#issue-3175534340

### 🛠 트러블슈팅 로그 요약
- 모바일과 PC에서 동시 로그인 시, Redis에 저장된 RT가 최신 로그인 디바이스 기준으로 덮어씌워짐
- 기존 디바이스에서는 만료된 RT로 AT 재발급을 시도하게 되어 400 `REFRESH_TOKEN_INVALID` 응답 발생
- 프론트는 해당 에러 발생 시 로그인 페이지로 리다이렉트하지만, 브라우저에 남아 있는 `accessToken`과 `hasLoggedIn=true`로 인해 자동 로그인 로직이 즉시 다시 실행됨
- 이로 인해  `/home` → `/login` → `/home` → `/login` 형태의 무한 루프 발생
- 이를 해결하기 위해 에러 감지 시 자동 로그인 조건을 명시적으로 제거하여 루프 차단
