### PR TITLE
v2.0.2

### DIFF
--- a/src/app/chat/individual/page.tsx
+++ b/src/app/chat/individual/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import dayjs from 'dayjs';
-import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { getChannelRooms } from '@/lib/api/chat';
 import { useRouter } from 'next/navigation';
 import Header from '@/components/layout/Header';
@@ -14,8 +14,6 @@ import ChatRoomNotFoundPage from '@/components/chat/ChatRoomNotFound';
 export default function ChannelsIndividualPage() {
   const router = useRouter();
   const { ref, inView } = useInView();
-
-  const queryClient = useQueryClient();
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError } =
     useInfiniteQuery({
@@ -71,18 +69,12 @@ export default function ChannelsIndividualPage() {
                   <div className="flex items-center gap-2 overflow-hidden">
                     <span
                       className={`rounded-2xl px-2 py-1 text-xs font-semibold ${
-                        room.relationType === 'SIGNAL'
-                          ? 'bg-[var(--gray-100)] text-[var(--blue)]'
-                          : room.relationType === 'MATCHING'
-                            ? 'bg-[var(--light-pink)] text-[var(--pink)]'
-                            : 'bg-[var(--gray-100)] text-[var(--gray-300)]'
+                        room.relationType === 'MATCHING'
+                          ? 'bg-[var(--light-pink)] text-[var(--pink)]'
+                          : 'bg-[var(--gray-100)] text-[var(--blue)]'
                       }`}
                     >
-                      {room.relationType === 'SIGNAL'
-                        ? '시그널'
-                        : room.relationType === 'MATCHING'
-                          ? '매칭'
-                          : '실패'}
+                      {room.relationType === 'MATCHING' ? '매칭' : '시그널'}
                     </span>
                     <span className="text-sm font-semibold text-ellipsis">
                       {room.partnerNickname}

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -1,5 +1,7 @@
 import { useConfirmModalStore } from '@/stores/modal/useConfirmModalStore';
 import Image from 'next/image';
+import { usePathname } from 'next/navigation';
+import { useEffect, useRef } from 'react';
 
 export function ConfirmModal() {
   const {
@@ -14,6 +16,16 @@ export function ConfirmModal() {
     variant = 'confirm',
     closeModal,
   } = useConfirmModalStore();
+
+  const pathname = usePathname();
+  const prevPathnameRef = useRef(pathname);
+
+  useEffect(() => {
+    if (isOpen && pathname !== prevPathnameRef.current) {
+      closeModal();
+    }
+    prevPathnameRef.current = pathname;
+  }, [pathname, isOpen, closeModal]);
 
   if (!isOpen) return null;
 
@@ -30,8 +42,8 @@ export function ConfirmModal() {
   };
 
   return isOpen ? (
-    <div className="fixed inset-0 z-51 flex items-center justify-center bg-black/40">
-      <div className="relative w-full max-w-xs space-y-4 rounded-2xl bg-white p-6 text-center">
+    <div className="pointer-events-none fixed inset-0 z-51 flex items-center justify-center bg-black/40">
+      <div className="pointer-events-auto relative w-full max-w-xs space-y-4 rounded-2xl bg-white p-6 text-center">
         {imageSrc && (
           <div className="flex w-full justify-center">
             <Image src={imageSrc} alt="friends Image" width={40} height={40} />

--- a/src/components/layout/ClientLayoutContent.tsx
+++ b/src/components/layout/ClientLayoutContent.tsx
@@ -35,16 +35,19 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
   const lastOpenedRoomIdRef = useRef<number | null>(null);
   const currentWaitingChannelIdRef = useRef<number | null>(null);
   const lastOpenedPartnerRef = useRef<string | null>(null);
-  const setHasResponded = useMatchingResponseStore((state) => state.setHasResponded);
   const shouldConnectSSE =
     pathname && !EXCLUDE_PATHS.some((excludedPath) => pathname.startsWith(excludedPath));
+
+  const getChannelRoomIdFromPath = (pathname: string): number | null => {
+    const match = pathname.match(/\/chat\/individual\/(\d+)/);
+    return match ? Number(match[1]) : null;
+  };
 
   const sseHandlers = useMemo(
     () => ({
       'signal-matching-conversion': (data: unknown) => {
-        const { partnerNickname, channelRoomId } = data as {
+        const { partnerNickname } = data as {
           partnerNickname: string;
-          channelRoomId: number;
         };
         toast.success(`🎉 ${partnerNickname}님과 매칭이 가능해졌어요!`);
       },
@@ -55,6 +58,9 @@ export default function ClientLayoutContent({ children }: { children: React.Reac
           hasResponded: boolean;
           partnerHasResponded: boolean;
         };
+
+        const currentRoomId = getChannelRoomIdFromPath(pathname);
+        if (currentRoomId !== channelRoomId) return;
 
         if (hasResponded || currentWaitingChannelIdRef.current === channelRoomId) return;
 

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -34,13 +34,25 @@ export const reissueAccessToken = async (): Promise<AccessTokenReissueResponse> 
   console.log('🔁 Token reissue 요청 보냄');
   axios.defaults.withCredentials = true;
 
-  const response = await axios.post<AccessTokenReissueResponse>(
-    `${BASE_URL}/v1/auth/token`,
-    {},
-    { withCredentials: true },
-  );
+  try {
+    const response = await axios.post<AccessTokenReissueResponse>(
+      `${BASE_URL}/v1/auth/token`,
+      {},
+      { withCredentials: true },
+    );
 
-  return response.data;
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const code = error.response?.data?.code;
+      if (code === 'REFRESH_TOKEN_INVALID') {
+        console.warn('❌ RefreshToken이 유효하지 않음');
+        window.location.href = '/login';
+      }
+    }
+
+    throw error;
+  }
 };
 
 interface DeleteLogoutResponse {

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -47,6 +47,7 @@ export const reissueAccessToken = async (): Promise<AccessTokenReissueResponse> 
       const code = error.response?.data?.code;
       if (code === 'REFRESH_TOKEN_INVALID') {
         console.warn('❌ RefreshToken이 유효하지 않음');
+        localStorage.setItem('hasLoggedIn', 'false');
         window.location.href = '/login';
       }
     }


### PR DESCRIPTION
### 🚀 연관된 이슈

<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
- 채팅 목록에서 UNMATCHED 일 때 시그널로 표시되도록 렌더링 조건 수정
- 매칭 모달 노출 시에도 닫기 버튼과 하단 네비게이션 바 클릭 가능하도록 수정
- 매칭 모달이 내 채팅방일 때만 뜨도록 예외 처리
- Access Token 재발급 API인 `/api/v1/auth/token`에서 넘겨주는 400 에러에 대한 예외 처리 진행
- Access Token 재발급 API(`/api/v1/auth/token`)에서 발생하는 400 `REFRESH_TOKEN_INVALID` 에러에 대한 예외 처리 로직 추가
- 해당 에러 발생 시 `hasLoggedIn` 값을 false로 설정하여 자동 로그인 조건을 해제
- 로그인 페이지 진입 시 불필요한 자동 로그인 시도를 차단하여 무한 리다이렉트 루프 방지



<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     | 기능 개선 / 버그 수정  |