### PR TITLE
마이페이지에서 `userInfo` 의존성으로 인한 사용자 정보 API 무한 호출 문제 해결

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -57,7 +57,7 @@ export default function MyPage() {
     };
 
     fetchUserInfo();
-  }, [userInfo]);
+  }, [userId]);
 
   if (!userInfo) {
     return <LoadingSpinner />;


### PR DESCRIPTION
### 🚀 연관된 이슈
- #131
<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
- 마이페이지에서 한 줄 소개 저장 후 GET `/api/v2/users/{userId}`가 무한 호출되는 문제 수정
- 문제의 원인은 useEffect의 의존성 배열에 userInfo가 포함되어 있어, 상태 변경 → 다시 fetch → 다시 상태 변경의 무한 루프가 발생함
- 의존성 배열을 userId로 수정하여 API가 단 1회만 호출되도록 개선

---

### ✨ 기존 코드
```ts
useEffect(() => {
  const fetchUserInfo = async () => {
    if (!userId) {
      console.error('userId가 없습니다.');
      return;
    }
    try {
      const response = await getUserInfo(userId);
      setUserInfo(response.data);
    } catch (error) {
      console.error('유저 정보 불러오기 실패: ', error);
    }
  };

  fetchUserInfo();
}, [userInfo]); ⬅️ 
```

---

### 🔁 현재 동작 흐름
1. `userInfo`가 null이기 때문에 처음에 `fetchUserInfo()` 실행됨
2. `setUserInfo(response.data)`가 실행되며 `userInfo`가 변경됨
3. `userInfo`가 변경되면 `useEffect(..., [userInfo])`가 다시 실행됨 → 또 `fetchUserInfo()` 호출
4. 다시 `setUserInfo()` → 다시 `userInfo` 변경 → 무한 반복

---

### 🛠 변경된 코드
```ts
useEffect(() => {
  const fetchUserInfo = async () => {
    if (!userId) {
      console.error('userId가 없습니다.');
      return;
    }
    try {
      const response = await getUserInfo(userId);
      setUserInfo(response.data);
    } catch (error) {
      console.error('유저 정보 불러오기 실패: ', error);
    }
  };

  fetchUserInfo();
}, [userId]); ⬅️ userId로 변경
```
<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     |  버그 수정   |