### PR TITLE
응답 중 입력창 비활성화 및 매칭 거절 시 제한 배너 표시 로직 개선

### DIFF
--- a/src/app/chat/individual/[channelRoomId]/page.tsx
+++ b/src/app/chat/individual/[channelRoomId]/page.tsx
@@ -60,6 +60,7 @@ export default function ChatsIndividualPage() {
   const bottomRef = useRef<HTMLDivElement>(null);
 
   const isWaitingModalVisible = useWaitingModalStore((state) => state.shouldShowModal);
+  const isMatchingResponseModalVisible = useMatchingResponseStore((state) => state.isModalOpen);
 
   const { data, isLoading, isError, error, fetchNextPage, hasNextPage } =
     useInfiniteQuery<ChannelRoomDetailResponse>({
@@ -354,13 +355,15 @@ export default function ChatsIndividualPage() {
         {isUnmatched && <UnavailableChannelBanner />}
         <ChatSignalInputBox
           onSend={handleSend}
-          disabled={isUnmatched || isWaitingModalVisible}
+          disabled={isUnmatched || isWaitingModalVisible || isMatchingResponseModalVisible}
           placeholder={
             isUnmatched
               ? '더 이상 메세지를 보낼 수 없습니다'
               : isWaitingModalVisible
                 ? '상대방 응답을 기다리는 중입니다'
-                : '메세지를 입력해주세요'
+                : isMatchingResponseModalVisible
+                  ? '상대방의 응답을 기다리는 중입니다'
+                  : '메세지를 입력해주세요'
           }
         />
       </div>

--- a/src/app/chat/individual/[channelRoomId]/page.tsx
+++ b/src/app/chat/individual/[channelRoomId]/page.tsx
@@ -188,7 +188,12 @@ export default function ChatsIndividualPage() {
     state.getHasResponded(parsedChannelRoomId),
   );
 
-  const isUnmatched = partner?.relationType === 'UNMATCHED' && hasResponded;
+  const relationTypeFromStore = useChannelRoomStore((state) =>
+    state.getRelationType(parsedChannelRoomId),
+  );
+  const effectiveRelationType = relationTypeFromStore ?? partner?.relationType;
+  const isUnmatched = effectiveRelationType === 'UNMATCHED' && hasResponded;
+
   const isFetchingRef = useRef(false);
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingRef.current) {

--- a/src/app/chat/individual/[channelRoomId]/page.tsx
+++ b/src/app/chat/individual/[channelRoomId]/page.tsx
@@ -59,6 +59,8 @@ export default function ChatsIndividualPage() {
 
   const bottomRef = useRef<HTMLDivElement>(null);
 
+  const isWaitingModalVisible = useWaitingModalStore((state) => state.shouldShowModal);
+
   const { data, isLoading, isError, error, fetchNextPage, hasNextPage } =
     useInfiniteQuery<ChannelRoomDetailResponse>({
       refetchOnMount: true,
@@ -349,18 +351,18 @@ export default function ChatsIndividualPage() {
         </div>
       </main>
       <div className="absolute bottom-14 w-full bg-white px-5 pt-2 pb-2">
-        {isUnmatched ? (
-          <>
-            <UnavailableChannelBanner />
-            <ChatSignalInputBox
-              onSend={handleSend}
-              disabled={true}
-              placeholder="더 이상 메세지를 보낼 수 없습니다"
-            />
-          </>
-        ) : (
-          <ChatSignalInputBox onSend={handleSend} placeholder="메세지를 입력해주세요" />
-        )}
+        {isUnmatched && <UnavailableChannelBanner />}
+        <ChatSignalInputBox
+          onSend={handleSend}
+          disabled={isUnmatched || isWaitingModalVisible}
+          placeholder={
+            isUnmatched
+              ? '더 이상 메세지를 보낼 수 없습니다'
+              : isWaitingModalVisible
+                ? '상대방 응답을 기다리는 중입니다'
+                : '메세지를 입력해주세요'
+          }
+        />
       </div>
     </>
   );

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -27,7 +27,9 @@ export function ConfirmModal() {
     prevPathnameRef.current = pathname;
   }, [pathname, isOpen, closeModal]);
 
-  if (!isOpen) return null;
+  const isChatIndividualPage = /^\/chat\/individual\/\d+/.test(pathname);
+
+  if (!isOpen || !isChatIndividualPage) return null;
 
   const isSingleButton = !cancelText;
 

--- a/src/constants/sseHandlers.tsx
+++ b/src/constants/sseHandlers.tsx
@@ -81,6 +81,7 @@ export const getSSEHandlers = ({
       console.log('[DEBUG] setHasResponded 여부 확인:', useMatchingResponseStore.getState());
       if (isAlreadyConfirmed || hasAlreadyResponded) return;
 
+      useMatchingResponseStore.getState().openModal();
       confirmModalStore.openModal({
         title: (
           <>

--- a/src/constants/sseHandlers.tsx
+++ b/src/constants/sseHandlers.tsx
@@ -135,6 +135,9 @@ export const getSSEHandlers = ({
           try {
             const res = await postMatchingReject({ channelRoomId });
             if (res.code === 'MATCH_REJECTION_SUCCESS') {
+              await queryClient.invalidateQueries({
+                queryKey: ['channelRoomDetail', channelRoomId],
+              });
               toast(`${partnerNickname}님과의 매칭을 거절했어요`, {
                 icon: '🙅‍♀️',
                 id: 'matching-reject',
@@ -228,11 +231,15 @@ export const getSSEHandlers = ({
     },
 
     'matching-rejection': (data: unknown) => {
-      const { partnerNickname } = data as MatchingPayload;
+      const { partnerNickname, channelRoomId } = data as MatchingPayload;
+
       useWaitingModalStore.getState().reset();
       toast(`${partnerNickname}님이 매칭을 거절했어요`, { icon: '🥲', id: 'matching-reject' });
-    },
 
+      useChannelRoomStore.getState().setRelationType(channelRoomId, 'UNMATCHED');
+
+      queryClient.invalidateQueries({ queryKey: ['channelRoomDetail', channelRoomId] });
+    },
     'nav-new-message': () => {
       navNewMessageStore.setHasNewMessage(true);
     },

--- a/src/stores/modal/useMatchingResponseStore.ts
+++ b/src/stores/modal/useMatchingResponseStore.ts
@@ -2,6 +2,9 @@ import { create } from 'zustand';
 
 interface MatchingResponseState {
   hasRespondedMap: Record<number, boolean>;
+  isModalOpen: boolean;
+  openModal: () => void;
+  closeModal: () => void;
   setHasResponded: (channelRoomId: number, value: boolean) => void;
   getHasResponded: (channelRoomId: number) => boolean;
   reset: (channelRoomId?: number) => void;
@@ -21,6 +24,10 @@ const getInitialState = (): Record<number, boolean> => {
 
 export const useMatchingResponseStore = create<MatchingResponseState>((set, get) => ({
   hasRespondedMap: getInitialState(),
+  isModalOpen: false,
+
+  openModal: () => set({ isModalOpen: true }),
+  closeModal: () => set({ isModalOpen: false }),
 
   setHasResponded: (channelRoomId, value) => {
     const updated = { ...get().hasRespondedMap, [channelRoomId]: value };


### PR DESCRIPTION
### 🚀 연관된 이슈
- #155
<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->



---

### 📝 작업 내용
- **응답중 모달이 떴을 때 채팅 입력창 비활성화**
  - 채팅방 진입 후 상대방이 매칭 응답 중일 때 띄워지는 `WaitingModal`이 열려 있을 경우, 사용자가 메시지를 입력하지 못하도록 채팅 입력창을 비활성화함
  -` useWaitingModalStore().shouldShowModal` 값을 감지하여 조건 제어
  
- **매칭 모달이 채팅 목록에서 뜨지 않도록 예외 처리 추가**
  - 채팅 목록(`/chat`) 페이지에서도 `WaitingModal` 또는 `ConfirmModal`이 뜨는 현상 방지
  - pathname 조건(`/chat/individual`)으로 제한하여 목록 페이지에서는 매칭 응답 모달이 뜨지 않도록 처리
  
- **매칭 확인 모달이 채팅 상세 페이지에서만 뜨도록 경로 제한**
  - 매칭 수락/거절 확인을 위한 `ConfirmModal`이 오직 채팅 상세 페이지에서만 노출되도록 경로 기반 조건 추가
  - 잘못된 위치에서 매칭 응답 모달이 떠서 혼란을 주던 문제 해결
  
- **매칭 거절 시 제한 배너가 바로 뜨지 않는 문제 해결**
  - 사용자가 매칭을 거절한 직후 `relationType: UNMATCHED` 상태가 반영되었음에도,
채팅 입력창 위 제한 배너(`UnavailableChannelBanner`)가 바로 렌더링되지 않던 문제를 수정
  - 상태 변경 후 강제로 상태를 업데이트해 바로 UI가 반영되도록 개선

https://github.com/user-attachments/assets/a9195beb-5bc7-4c4a-8f59-cd440e8a4b9f

<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     | 기능 개선 / 버그 수정 |

### ✅ 테스트 목록

- [x]	응답 중에는 채팅 입력이 비활성화되는지 확인
- [x]	채팅 목록에서는 매칭 응답 모달이 뜨지 않는지 확인
- [x]	채팅 상세 페이지에서만 모달이 뜨는지 확인
- [x]	매칭 거절 직후 제한 배너가 뜨는지 확인