### PR TITLE
마이페이지에서 ConfirmModal이 렌더링되지 않던 문제 수정

### DIFF
--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -28,8 +28,10 @@ export function ConfirmModal() {
   }, [pathname, isOpen, closeModal]);
 
   const isChatIndividualPage = /^\/chat\/individual\/\d+/.test(pathname);
+  const isMyPage = pathname === '/mypage';
+  const isLogoutModal = variant === 'quit';
 
-  if (!isOpen || !isChatIndividualPage) return null;
+  if (!isOpen || (!isChatIndividualPage && !isMyPage && !isLogoutModal)) return null;
 
   const isSingleButton = !cancelText;
 


### PR DESCRIPTION
### 🚀 연관된 이슈
- #158
<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
- `ConfirmModal`이 마이페이지에서 로그아웃 모달까지 차단하던 문제 해결
  - `ConfirmModal`이 채팅 상세 경로(`/chat/individual/:id`)에서만 뜨도록 제한되어 있어, 마이페이지에서 로그아웃 모달이 렌더링되지 않던 이슈 해결
  - 마이페이지에서는 로그아웃 `ConfirmModal`이 정상적으로 뜨도록 예외 조건 분기 처리

<img width="500" height="764" alt="스크린샷 2025-07-20 오후 8 40 44" src="https://github.com/user-attachments/assets/a87e5dd1-5025-42bf-8afb-4abd86aa12ef" />

<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     | 버그 수정  |

### ✅ 테스트 목록

- [x] 마이페이지에서 로그아웃 버튼 클릭 시 `ConfirmModal`이 정상적으로 뜨는지 확인
- [x] 채팅 상세 페이지 외 다른 경로에서는 `ConfirmModal`이 뜨지 않는지 확인
