### PR TITLE
채팅 입력창 비활성화 조건을 현재 채팅방에만 적용하도록 수정

### DIFF
--- a/src/app/chat/individual/[channelRoomId]/page.tsx
+++ b/src/app/chat/individual/[channelRoomId]/page.tsx
@@ -276,6 +276,12 @@ export default function ChatsIndividualPage() {
     });
   };
 
+  const isWaitingInThisRoom =
+    isWaitingModalVisible && waitingModalChannelId === parsedChannelRoomId;
+
+  const isMatchingInThisRoom =
+    isMatchingResponseModalVisible && waitingModalChannelId === parsedChannelRoomId;
+
   const handleLeaveChatRoom = (channelRoomId: number, partnerNickname: string) => {
     useConfirmModalStore.getState().openModal({
       title: '정말 채팅방을 나가시겠어요?',
@@ -360,14 +366,14 @@ export default function ChatsIndividualPage() {
         {isUnmatched && <UnavailableChannelBanner />}
         <ChatSignalInputBox
           onSend={handleSend}
-          disabled={isUnmatched || isWaitingModalVisible || isMatchingResponseModalVisible}
+          disabled={isUnmatched || isWaitingInThisRoom || isMatchingInThisRoom}
           placeholder={
             isUnmatched
               ? '더 이상 메세지를 보낼 수 없습니다'
               : isWaitingModalVisible
-                ? '상대방 응답을 기다리는 중입니다'
+                ? '메세지를 입력해주세요'
                 : isMatchingResponseModalVisible
-                  ? '상대방의 응답을 기다리는 중입니다'
+                  ? '메세지를 입력해주세요'
                   : '메세지를 입력해주세요'
           }
         />

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -36,7 +36,7 @@ export const useSSE = ({
       isConnectingRef.current = true;
 
       if (eventSourceRef.current) {
-        console.log(`[기존 SSE 연결 해제] channelRoomId: ${channelRoomId}`);
+        console.log(`[기존 SSE 연결 해제]`);
         Object.entries(listenerMapRef.current).forEach(([event, listener]) => {
           eventSourceRef.current!.removeEventListener(event, listener);
         });
@@ -49,7 +49,7 @@ export const useSSE = ({
       listenerMapRef.current = {};
 
       eventSource.onopen = () => {
-        console.log(`[SSE 연결 완료] channelRoomId: ${channelRoomId}`);
+        console.log(`[SSE 연결 완료]`);
         isConnectingRef.current = false;
         lastHeartbeatRef.current = Date.now();
       };


### PR DESCRIPTION
### 🚀 연관된 이슈
- #161
<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
- 응답중 상태가 현재 채팅방에만 적용되도록 입력창 비활성화 조건 수정
- 전역 상태에 의한 채팅 제한 문제 해결
- 각 채팅방 독립적으로 메시지 입력 가능하도록 로직 수정
<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

https://github.com/user-attachments/assets/6e32a891-3260-407a-9308-550fba5837e6


---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     | 버그 수정  |

### ✅ 테스트 목록

- [ ] 응답 중 모달이 떠 있는 채팅방에서만 입력창 비활성화되는지 확인
- [ ] 다른 채팅방에서는 입력 가능하며, 메시지 정상 전송되는지 확인
- [ ] 관계 상태가 UNMATCHED일 때 안내 문구 및 입력 불가 처리 확인

---

### 📎 참고 자료

<!-- 디자인 시안, 기획 문서, 관련 링크 등 참고할 만한 자료가 있다면 첨부해주세요
- [Figma 시안](https://figma.com/xyz)
- [기획 노션 문서](https://notion.so/project/abc) -->

---

### 📌 기타

<!-- 추가로 공유하고 싶은 내용이 있다면 자유롭게 작성해주세요
- 코드 리팩토링 대상이지만 현재는 기능 우선으로 구현했습니다 (추후 리팩토링 예정) -->
