### PR TITLE
FCM 푸시 알림 클릭 시 홈으로 이동 처리 및 기본 문구 적용

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,10 +1,30 @@
 self.addEventListener('push', function (event) {
-  const data = event.data?.json();
-  const { title, body } = data?.notification || {};
-
   event.waitUntil(
-    self.registration.showNotification(title || '📬 푸시 알림을 보내드릴게요!', {
-      body: body || '튜닝에서 놓치지 말아야 할 소식을 실시간으로 확인해보세요.',
-    }),
+    (async () => {
+      try {
+        const rawText = await event.data?.text();
+        console.log('[Raw push data]', rawText);
+
+        const parsed = JSON.parse(rawText);
+        const payload = parsed.data || {};
+
+        console.log('[ServiceWorker] Push Received with data:', parsed);
+        console.log('[data.title] Push Received with data title:', payload.title);
+
+        const title = payload.title || '📬 푸시 알림을 보내드릴게요!';
+        const body = payload.content || '튜닝에서 놓치지 말아야 할 소식을 실시간으로 확인해보세요.';
+
+        self.registration.showNotification(title, {
+          body,
+          icon: 'https://hertz-tuning.com/icons/favicon.png',
+          tag: 'tuning-push',
+          data: {
+            url: 'https://hertz-tuning.com',
+          },
+        });
+      } catch (err) {
+        console.error('[ServiceWorker] Push 처리 중 오류 발생', err);
+      }
+    })(),
   );
 });

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -21,3 +21,11 @@ self.addEventListener('push', (event) => {
     event.waitUntil(self.registration.showNotification(title, options));
   }
 });
+
+self.addEventListener('notificationclick', function (event) {
+  event.notification.close();
+  const url = event.notification.data?.url;
+  if (url) {
+    event.waitUntil(clients.openWindow(url));
+  }
+});


### PR DESCRIPTION
### 🚀 연관된 이슈
- #151 
<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
- FCM 푸시 알림 클릭 시 사용자가 홈(/) 페이지로 이동하도록 처리
- 푸시 알림에 title, content가 없는 경우, 예외 상황에도 사용자에게 자연스러운 메시지가 노출되도록 fallback 처리

<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     | 기능 개선   |

### ✅ 테스트 목록

- [ ] FCM 푸시 수신 시 알림 정상 노출 확인
- [ ] 알림 클릭 시 홈 페이지(/)로 정상 이동 여부 확인
- [ ] title, content 미포함된 경우 서버 기본 문구로 대체되는지 확인

---

### 📌 기타
- 현재는 홈 페이지로만 이동하도록 처리했으며, 추후 알림 유형에 따라 라우팅 분기 처리 예정입니다.
- 푸시 알림 기본 문구는 서버 응답 형식이 변경되면 별도로 핸들링을 위한 수정이 필요할 수 있습니다.

<!-- 추가로 공유하고 싶은 내용이 있다면 자유롭게 작성해주세요
- 코드 리팩토링 대상이지만 현재는 기능 우선으로 구현했습니다 (추후 리팩토링 예정) -->
