### PR TITLE
채팅방 `UNMATCHED` 상태 채팅 제한 및 전역 모달 상태 관리 개선

### DIFF
--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -1,7 +1,5 @@
 import { useConfirmModalStore } from '@/stores/modal/useConfirmModalStore';
 import Image from 'next/image';
-import { usePathname } from 'next/navigation';
-import { useEffect, useRef } from 'react';
 
 export function ConfirmModal() {
   const {
@@ -17,18 +15,8 @@ export function ConfirmModal() {
     closeModal,
   } = useConfirmModalStore();
 
-  const pathname = usePathname();
-  const prevPathnameRef = useRef(pathname);
-
-  useEffect(() => {
-    if (isOpen && pathname !== prevPathnameRef.current) {
-      closeModal();
-    }
-    prevPathnameRef.current = pathname;
-  }, [pathname, isOpen, closeModal]);
-
-  const isChatIndividualPage = /^\/chat\/individual\/\d+/.test(pathname);
-  const isMyPage = pathname === '/mypage';
+  const isChatIndividualPage = /^\/chat\/individual\/\d+/.test(window.location.pathname);
+  const isMyPage = window.location.pathname === '/mypage';
   const isLogoutModal = variant === 'quit';
 
   if (!isOpen || (!isChatIndividualPage && !isMyPage && !isLogoutModal)) return null;

--- a/src/components/layout/ChatHeader.tsx
+++ b/src/components/layout/ChatHeader.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useWaitingModalStore } from '@/stores/modal/useWaitingModalStore';
 import { useRouter } from 'next/navigation';
-import { FaAngleLeft, FaAngleDown } from 'react-icons/fa6';
+import { FaAngleLeft, FaAngleDown } from 'react-icons/fa';
 import { LuLogOut } from 'react-icons/lu';
+import { useWaitingModalStore } from '@/stores/modal/useWaitingModalStore';
+import { useMatchingResponseStore } from '@/stores/modal/useMatchingResponseStore';
 
 interface ChatHeaderProps {
   title: string;
@@ -14,6 +15,7 @@ interface ChatHeaderProps {
 export default function ChatHeader({ title, partnerId, onLeave }: ChatHeaderProps) {
   const router = useRouter();
   const closeModal = useWaitingModalStore((state) => state.closeModal);
+  const { temporarilyHideModal } = useMatchingResponseStore();
 
   const handleNicknameClick = () => {
     router.push(`/profile/${partnerId}`);
@@ -21,6 +23,13 @@ export default function ChatHeader({ title, partnerId, onLeave }: ChatHeaderProp
 
   const handleBack = () => {
     closeModal();
+    // 현재 채팅방 ID를 URL에서 추출하여 모달 임시 숨김
+    const currentPath = window.location.pathname;
+    const match = currentPath.match(/\/chat\/individual\/(\d+)/);
+    if (match) {
+      const channelRoomId = Number(match[1]);
+      temporarilyHideModal(channelRoomId);
+    }
     router.back();
   };
   return (

--- a/src/constants/sseHandlers.tsx
+++ b/src/constants/sseHandlers.tsx
@@ -264,11 +264,9 @@ export const getSSEHandlers = ({
     },
 
     'new-signal-reception': (data: unknown) => {
-      const { partnerNickname } = data as { partnerNickname: string };
-      toast(`${partnerNickname}님에게 첫 메세지가 도착했어요!`, {
-        icon: '💬',
-        duration: 4000,
-      });
+      const message = data as NewMessageType;
+      newMessageStore.showToast(message);
+      queryClient.invalidateQueries({ queryKey: ['channelRooms'] });
     },
   };
 };

--- a/src/constants/sseHandlers.tsx
+++ b/src/constants/sseHandlers.tsx
@@ -223,7 +223,7 @@ export const getSSEHandlers = ({
 
       try {
         await queryClient.invalidateQueries({
-          queryKey: ['channelRoomDetail', channelRoomId],
+          queryKey: ['channelRoom', channelRoomId],
         });
       } catch (e) {
         console.error('채팅방 정보를 갱신하는 데 실패했습니다:', e);
@@ -238,7 +238,7 @@ export const getSSEHandlers = ({
 
       useChannelRoomStore.getState().setRelationType(channelRoomId, 'UNMATCHED');
 
-      queryClient.invalidateQueries({ queryKey: ['channelRoomDetail', channelRoomId] });
+      queryClient.invalidateQueries({ queryKey: ['channelRoom', channelRoomId] });
     },
     'nav-new-message': () => {
       navNewMessageStore.setHasNewMessage(true);

--- a/src/stores/modal/useNewMessageStore.ts
+++ b/src/stores/modal/useNewMessageStore.ts
@@ -7,6 +7,8 @@ interface NewMessage {
   message: string;
   messageSendAt: string;
   partnerProfileImage: string;
+  relationType: string;
+  lastPageNumber: number;
 }
 
 interface NewMessageStore {

--- a/src/stores/modal/useWaitingModalStore.ts
+++ b/src/stores/modal/useWaitingModalStore.ts
@@ -4,18 +4,26 @@ import { persist } from 'zustand/middleware';
 interface WaitingModalState {
   isOpen: boolean;
   shouldShowModal: boolean;
+  isTemporarilyHidden: boolean;
+  hiddenChannelRoomId: number | null;
+  hiddenModalData: { partnerNickname: string; channelRoomId: number } | null;
   partnerNickname: string;
   channelRoomId: number | null;
   openModal: (nickname: string, channelRoomId: number) => void;
   closeModal: () => void;
+  temporarilyHideModal: (channelRoomId: number) => void;
+  restoreModal: (channelRoomId: number) => void;
   reset: () => void;
 }
 
 export const useWaitingModalStore = create<WaitingModalState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       isOpen: false,
       shouldShowModal: false,
+      isTemporarilyHidden: false,
+      hiddenChannelRoomId: null,
+      hiddenModalData: null,
       partnerNickname: '',
       channelRoomId: null,
 
@@ -23,6 +31,7 @@ export const useWaitingModalStore = create<WaitingModalState>()(
         set({
           isOpen: true,
           shouldShowModal: true,
+          isTemporarilyHidden: false,
           partnerNickname: nickname,
           channelRoomId,
         }),
@@ -33,10 +42,46 @@ export const useWaitingModalStore = create<WaitingModalState>()(
           isOpen: false,
         })),
 
+      temporarilyHideModal: (channelRoomId) => {
+        const state = get();
+        if (state.isOpen) {
+          set({
+            isOpen: false,
+            isTemporarilyHidden: true,
+            hiddenChannelRoomId: channelRoomId,
+            hiddenModalData: {
+              partnerNickname: state.partnerNickname,
+              channelRoomId: state.channelRoomId!,
+            },
+          });
+        }
+      },
+
+      restoreModal: (channelRoomId) => {
+        const state = get();
+        if (
+          state.isTemporarilyHidden &&
+          state.hiddenChannelRoomId === channelRoomId &&
+          state.hiddenModalData
+        ) {
+          set({
+            isOpen: true,
+            isTemporarilyHidden: false,
+            hiddenChannelRoomId: null,
+            partnerNickname: state.hiddenModalData.partnerNickname,
+            channelRoomId: state.hiddenModalData.channelRoomId,
+            hiddenModalData: null,
+          });
+        }
+      },
+
       reset: () =>
         set({
           isOpen: false,
           shouldShowModal: false,
+          isTemporarilyHidden: false,
+          hiddenChannelRoomId: null,
+          hiddenModalData: null,
           partnerNickname: '',
           channelRoomId: null,
         }),

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -5,4 +5,6 @@ export type NewMessageType = {
   message: string;
   messageSendAt: string;
   partnerProfileImage: string;
+  relationType: string;
+  lastPageNumber: number;
 };


### PR DESCRIPTION
### 🚀 연관된 이슈

- #170

---

### 📝 작업 내용

1. **UNMATCHED 상태 채팅 제한 버그 수정**
   - `relationType='UNMATCHED'`일 때 `hasResponded` 조건과 관계없이 무조건 채팅 제한 적용
   - SSE 연결 안정성 개선 (불필요한 재연결 로직 제거)

2. **모달 임시 숨김/복원 시스템 구현**
   - 브라우저 뒤로가기 시 매칭 모달, 응답중 모달을 임시로 숨기고 다시 채팅방에 돌아왔을 때 복원하는 기능
   - `ConfirmModal`, `WaitingModal`, `MatchingResponseModal` 모두 적용

3. **전역 모달 관리 시스템 적용**
   - 모바일 스와이프, 마우스 뒤로가기 버튼, 헤더 버튼 등 모든 네비게이션 방식 지원
   - `ClientLayoutContent`에서 전역적으로 모달 상태 관리

4. **SSE 메시지 알림 개선**
   - `lastPageNumber` 필드 추가로 정확한 페이지네이션 지원
   - 첫 시그널과 일반 메시지 모두 통일된 토스트 UI로 표시


---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     | 버그 수정 / 기능 개선 / 신규 기능                      |
| 영향 범위     | 채팅방 페이지, 모달 컴포넌트, SSE 핸들러, 토스트 알림  |
| 추가 리팩토링 | 없음                                                   |

---

### ✅ 테스트 목록

- [ ] UNMATCHED 상태에서 채팅 입력이 비활성화되는지 확인
- [ ] UNMATCHED 상태에서 "더 이상 메세지를 보낼 수 없습니다" 메시지 표시 확인
- [ ] 매칭 응답 모달이 열린 상태에서 브라우저 뒤로가기 시 모달이 사라지는지 확인
- [ ] 다시 채팅방으로 돌아왔을 때 모달이 복원되는지 확인
- [ ] 응답중 모달(WaitingModal)도 동일하게 숨김/복원되는지 확인
- [ ] 모바일에서 스와이프 뒤로가기 시 모달 처리 확인
- [ ] SSE 메시지 토스트 클릭 시 올바른 페이지로 이동하는지 확인

---

### 📎 참고 자료

- SSE 이벤트 명세서 (`new-message-reception`, `new-signal-reception`에 `lastPageNumber` 추가)
<img width="1270" height="280" alt="image" src="https://github.com/user-attachments/assets/6e416ef3-534c-4d00-a4a2-e1cdb498e95c" />

---

### 📌 기타

- SSE 재연결 로직을 제거하여 모달 이벤트 누락 문제 해결
- zustand를 사용해 전역으로 관리해 모든 종류의 뒤로가기 동작에 대응 가능