### PR TITLE
채팅방 최초 진입 시 WebSocket 연결 실패 및 안정성 문제 해결

### DIFF
--- a/src/hooks/useSocketIO.ts
+++ b/src/hooks/useSocketIO.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import type {
   MarkAsRead,
   ReceiveMessage,
@@ -11,20 +11,37 @@ import type {
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const io = require('socket.io-client');
+
 interface UseSocketIOProps {
   channelRoomId: number;
   onMessage: (data: WebSocketIncomingMessage) => void;
 }
 
-export const useSocketIO = ({ channelRoomId, onMessage }: UseSocketIOProps) => {
+interface UseSocketIOReturn {
+  socketRef: React.MutableRefObject<ReturnType<typeof io> | null>;
+  sendSocketMessage: (payload: SendMessage) => void;
+  sendMarkAsRead: (payload: MarkAsRead) => void;
+  isConnected: boolean;
+  reconnect: () => void;
+}
+
+export const useSocketIO = ({ channelRoomId, onMessage }: UseSocketIOProps): UseSocketIOReturn => {
   const socketRef = useRef<ReturnType<typeof io> | null>(null);
   const onMessageRef = useRef(onMessage);
+  const reconnectAttemptRef = useRef(0);
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const isConnectingRef = useRef(false);
+
+  const [isConnected, setIsConnected] = useState(false);
+
+  const MAX_RECONNECT_ATTEMPTS = 5;
+  const RECONNECT_DELAY = 2000;
 
   useEffect(() => {
     onMessageRef.current = onMessage;
   }, [onMessage]);
 
-  useEffect(() => {
+  const connectSocket = useCallback(() => {
     const websocketUrl = process.env.NEXT_PUBLIC_WEBSOCKET_URL;
 
     if (!websocketUrl) {
@@ -32,13 +49,25 @@ export const useSocketIO = ({ channelRoomId, onMessage }: UseSocketIOProps) => {
       return;
     }
 
-    console.log('🔗 WebSocket 연결 시도:', { url: websocketUrl, channelRoomId });
+    if (isConnectingRef.current) {
+      return;
+    }
+
+    isConnectingRef.current = true;
+
+    if (socketRef.current) {
+      socketRef.current.removeAllListeners();
+      socketRef.current.disconnect();
+    }
 
     const socket = io(websocketUrl, {
       transports: ['websocket'],
       withCredentials: true,
       path: '/socket.io',
-      forceNew: true,
+      timeout: 10000,
+      reconnection: true,
+      reconnectionDelay: RECONNECT_DELAY,
+      reconnectionAttempts: MAX_RECONNECT_ATTEMPTS,
       upgrade: false,
     });
 
@@ -46,22 +75,59 @@ export const useSocketIO = ({ channelRoomId, onMessage }: UseSocketIOProps) => {
 
     const handleConnect = () => {
       console.log('✅ Socket.IO 연결 성공', { channelRoomId });
+      setIsConnected(true);
+      isConnectingRef.current = false;
+      reconnectAttemptRef.current = 0;
+
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
     };
-    const handleDisconnect = () => {
-      console.log('🔌 Socket.IO 연결 해제', { channelRoomId });
+
+    const handleDisconnect = (reason: string) => {
+      console.log('🔌 Socket.IO 연결 해제', { channelRoomId, reason });
+      setIsConnected(false);
+      isConnectingRef.current = false;
+
+      if (reason !== 'io client disconnect') {
+        attemptReconnect();
+      }
     };
+
     const handleConnectError = (err: Error) => {
       console.error('❌ Socket.IO 연결 실패:', err, {
         channelRoomId,
-        url: process.env.NEXT_PUBLIC_WEBSOCKET_URL,
+        url: websocketUrl,
+        attempt: reconnectAttemptRef.current + 1,
       });
+      setIsConnected(false);
+      isConnectingRef.current = false;
+      attemptReconnect();
     };
+
+    const attemptReconnect = () => {
+      if (reconnectAttemptRef.current >= MAX_RECONNECT_ATTEMPTS) {
+        console.error('❌ 최대 재연결 시도 횟수 초과', { channelRoomId });
+        return;
+      }
+
+      reconnectAttemptRef.current += 1;
+      const delay = RECONNECT_DELAY * reconnectAttemptRef.current;
+
+      reconnectTimeoutRef.current = setTimeout(() => {
+        connectSocket();
+      }, delay);
+    };
+
     const handleInitUser = (data: number) => {
       onMessageRef.current({ event: 'init_user', data });
     };
+
     const handleReceiveMessage = (data: ReceiveMessage) => {
       onMessageRef.current({ event: 'receive_message', data });
     };
+
     const handleRelationTypeChanged = (data: RelationTypeChanged) => {
       onMessageRef.current({ event: 'relation_type_changed', data });
     };
@@ -72,18 +138,39 @@ export const useSocketIO = ({ channelRoomId, onMessage }: UseSocketIOProps) => {
     socket.on('init_user', handleInitUser);
     socket.on('receive_message', handleReceiveMessage);
     socket.on('relation_type_changed', handleRelationTypeChanged);
+  }, [channelRoomId]);
+
+  const reconnect = useCallback(() => {
+    reconnectAttemptRef.current = 0;
+
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+
+    connectSocket();
+  }, [connectSocket]);
+
+  useEffect(() => {
+    connectSocket();
 
     return () => {
-      socket.off('connect', handleConnect);
-      socket.off('disconnect', handleDisconnect);
-      socket.off('connect_error', handleConnectError);
-      socket.off('init_user', handleInitUser);
-      socket.off('receive_message', handleReceiveMessage);
-      socket.off('relation_type_changed', handleRelationTypeChanged);
-      socket.removeAllListeners();
-      socket.disconnect();
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
+
+      if (socketRef.current) {
+        socketRef.current.removeAllListeners();
+        socketRef.current.disconnect();
+        socketRef.current = null;
+      }
+
+      setIsConnected(false);
+      isConnectingRef.current = false;
+      reconnectAttemptRef.current = 0;
     };
-  }, [channelRoomId]);
+  }, [connectSocket]);
 
   const sendSocketMessage = (payload: SendMessage) => {
     if (!socketRef.current) {
@@ -115,5 +202,7 @@ export const useSocketIO = ({ channelRoomId, onMessage }: UseSocketIOProps) => {
     socketRef,
     sendSocketMessage,
     sendMarkAsRead,
+    isConnected,
+    reconnect,
   };
 };


### PR DESCRIPTION
### 🚀 연관된 이슈

- #174

---

### 📝 작업 내용

- 채팅방 WebSocket 연결 안정성 및 자동 재연결 기능 구현

#### 🐞 문제 상황
- 채팅방 최초 진입 시 WebSocket 연결 실패 → 새로고침 전까지 소켓 연결이 이루어지지 않음
- 네트워크 불안정 시 수동 복구 필요 → 연결 끊김 시 사용자가 직접 새로고침해야 함
- 연결 확인 없이 메시지 전송을 시도해 전송 실패 가능성이 있음

#### 🔧 구현된 해결책

**1. WebSocket 연결 안정성 강화**
- 자동 재연결 메커니즘 구현 (최대 5회, 점진적 지연 구현 `2초 → 4초 → 6초`)
- 10초 타임아웃 설정으로 빠른 실패 감지
- 중복 연결 시도 방지 및 리소스 정리 최적화
- `forceNew` 옵션 제거로 불필요한 새 연결 생성 방지

**2. 실시간 연결 상태 추적**
- `isConnected` 상태로 연결 여부 실시간 모니터링
- `reconnect()` 함수로 수동 재연결 기능 제공
- 연결 상태 변화에 따른 UI 즉시 반영

**3. 사용자 경험 개선**
- 연결 상태별 입력창 비활성화 및 안내 메시지
- 연결 끊김 시 토스트 알림 및 3초 후 자동 재연결
- 메시지 전송/읽음 처리 전 연결 상태 선행 체크
- 연결 실패 시 명확한 오류 메시지 및 자동 복구 시도

---

### 🛠 변경 사항 요약

| 항목          | 내용                                                   |
| ------------- | ------------------------------------------------------ |
| 기능 유형     | **버그 수정** + **기능 개선** (WebSocket 연결 안정성) |
| 영향 범위     | 개별 채팅방 페이지, WebSocket 훅, 실시간 통신 전반 |
| 관련 파일     | **있음** - `useSocketIO.ts` (훅 개선), `page.tsx` (UI 연동) |
| 추가 리팩토링 | **없음** - 기존 아키텍처 유지하며 안정성만 강화 |

---

### ✅ 테스트 목록

#### 🔍 기능 테스트
- [x] 채팅방 최초 진입 시 WebSocket 자동 연결 확인
- [x] 네트워크 끊김 시 자동 재연결 동작 확인 (최대 5회)
- [x] 연결 실패 시 사용자 알림 및 토스트 메시지 표시 확인
- [x] 수동 재연결 기능 (`reconnect()`) 정상 동작 확인

#### 🎯 UI/UX 테스트  
- [x] 연결 상태에 따른 입력창 비활성화 확인
- [x] 연결 중일 때 "연결 중... 잠시만 기다려주세요" 메시지 표시
- [x] 연결 끊김 시 메시지 전송 차단 및 오류 메시지 확인
- [x] 3초 후 자동 재연결 시도 및 토스트 알림 확인

#### 🚀 성능 테스트
- [x] 중복 연결 시도 방지 로직 동작 확인
- [x] 컴포넌트 언마운트 시 리소스 정리 확인
- [x] 메시지 전송/읽음 처리 시 연결 상태 체크 확인
- [x] 점진적 재연결 지연 (2초 → 4초 → 6초) 동작 확인
- [x] 불필요한 연결 생성 방지 (`forceNew` 제거) 확인
- [x] 타임아웃 설정 (10초)으로 빠른 실패 감지 확인
- [x] 기존 채팅 기능에 성능 영향 없음 확인

---

### 📁 수정된 파일

#### `src/hooks/useSocketIO.ts`
**핵심 개선사항:**
- `isConnected` 상태 및 `reconnect` 함수 추가
- 자동 재연결 로직 구현 (`attemptReconnect`, 점진적 지연)
- 연결 상태 추적 및 중복 연결 방지
- 타임아웃 설정 및 리소스 정리 최적화

#### `src/app/chat/individual/[channelRoomId]/page.tsx`
**핵심 개선사항:**
- 연결 상태 모니터링 및 자동 재연결 로직
- `handleSend`에서 연결 상태 선행 체크
- 연결 상태별 입력창 비활성화 및 placeholder 변경
- 읽음 처리 시 연결 상태 확인
