### PR TITLE
Dynamic Import를 활용한 코드 스플리팅 및 번들 크기 최적화

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, useState, useEffect } from 'react';
 import dynamic from 'next/dynamic';
-import { MatchTypeSelector } from '@/components/home/MatchTypeSelector';
 
-import StaticPerformanceMonitor from '@/components/performance/StaticPerformanceMonitor';
+const DynamicStaticPerformanceMonitor = dynamic(
+  () => import('@/components/performance/StaticPerformanceMonitor'),
+  {
+    ssr: false,
+  },
+);
 
 const BannerSection = dynamic(() => import('@/components/home/BannerSection'), {
   ssr: false,
@@ -25,10 +29,53 @@ const ClickWebPushBanner = dynamic(() => import('@/components/home/ClickWebPushB
   loading: () => <div className="h-12 animate-pulse rounded bg-gray-100" />,
 });
 
+const MatchTypeSelector = dynamic(
+  () =>
+    import('@/components/home/MatchTypeSelector').then((mod) => ({
+      default: mod.MatchTypeSelector,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex w-full flex-col items-center justify-center py-10">
+        <div className="w-90 items-center rounded-2xl bg-gray-100 px-6 py-5">
+          <div className="mb-4 h-5 w-48 animate-pulse rounded bg-gray-300" />
+          <div className="flex items-center justify-around">
+            {[...Array(2)].map((_, i) => (
+              <div key={i} className="flex flex-col items-center space-y-1">
+                <div className="h-15 w-15 animate-pulse rounded-full bg-gray-200" />
+                <div className="h-4 w-12 animate-pulse rounded bg-gray-300" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    ),
+  },
+);
+
 export default function HomePage() {
+  const [shouldLoadBelowFold, setShouldLoadBelowFold] = useState(false);
+  const [shouldLoadMatchTypeSelector, setShouldLoadMatchTypeSelector] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShouldLoadBelowFold(true);
+    }, 300);
+
+    const matchTypeSelectorTimer = setTimeout(() => {
+      setShouldLoadMatchTypeSelector(true);
+    }, 500);
+
+    return () => {
+      clearTimeout(timer);
+      clearTimeout(matchTypeSelectorTimer);
+    };
+  }, []);
+
   return (
     <>
-      <StaticPerformanceMonitor pageName="/home (Static SSR with Layout)" />
+      <DynamicStaticPerformanceMonitor pageName="/home (Dynamic Import)" />
 
       <main className="p-4">
         <Suspense
@@ -42,20 +89,67 @@ export default function HomePage() {
           <ClickWebPushBanner />
         </Suspense>
 
-        <Suspense
-          fallback={
-            <div className="mx-auto mt-6 w-full max-w-md">
-              <div className="relative aspect-[3/2] animate-pulse rounded-lg bg-gray-200" />
-              <div className="mt-4 flex justify-center space-x-2">
-                {[...Array(5)].map((_, i) => (
-                  <div key={i} className="h-2 w-2 rounded-full bg-gray-300" />
+        {shouldLoadBelowFold ? (
+          <Suspense
+            fallback={
+              <div className="mx-auto mt-6 w-full max-w-md">
+                <div className="relative aspect-[3/2] animate-pulse rounded-lg bg-gray-200" />
+                <div className="mt-4 flex justify-center space-x-2">
+                  {[...Array(5)].map((_, i) => (
+                    <div key={i} className="h-2 w-2 rounded-full bg-gray-300" />
+                  ))}
+                </div>
+              </div>
+            }
+          >
+            <BannerSection />
+          </Suspense>
+        ) : (
+          <div className="mx-auto mt-6 w-full max-w-md">
+            <div className="relative aspect-[3/2] animate-pulse rounded-lg bg-gray-200" />
+            <div className="mt-4 flex justify-center space-x-2">
+              {[...Array(5)].map((_, i) => (
+                <div key={i} className="h-2 w-2 rounded-full bg-gray-300" />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {shouldLoadMatchTypeSelector ? (
+          <Suspense
+            fallback={
+              <div className="flex w-full flex-col items-center justify-center py-10">
+                <div className="w-90 items-center rounded-2xl bg-gray-100 px-6 py-5">
+                  <div className="mb-4 h-5 w-48 animate-pulse rounded bg-gray-300" />
+                  <div className="flex items-center justify-around">
+                    {[...Array(2)].map((_, i) => (
+                      <div key={i} className="flex flex-col items-center space-y-1">
+                        <div className="h-15 w-15 animate-pulse rounded-full bg-gray-200" />
+                        <div className="h-4 w-12 animate-pulse rounded bg-gray-300" />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            }
+          >
+            <MatchTypeSelector />
+          </Suspense>
+        ) : (
+          <div className="flex w-full flex-col items-center justify-center py-10">
+            <div className="w-90 items-center rounded-2xl bg-gray-100 px-6 py-5">
+              <div className="mb-4 h-5 w-48 animate-pulse rounded bg-gray-300" />
+              <div className="flex items-center justify-around">
+                {[...Array(2)].map((_, i) => (
+                  <div key={i} className="flex flex-col items-center space-y-1">
+                    <div className="h-15 w-15 animate-pulse rounded-full bg-gray-200" />
+                    <div className="h-4 w-12 animate-pulse rounded bg-gray-300" />
+                  </div>
                 ))}
               </div>
             </div>
-          }
-        >
-          <BannerSection /> <MatchTypeSelector />
-        </Suspense>
+          </div>
+        )}
       </main>
     </>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,14 @@
 import '@app/globals.css';
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
-import { Toaster } from 'react-hot-toast';
 import OptimizedClientLayout from '@/components/layout/OptimizedClientLayout';
 import Providers from './providers';
 import Script from 'next/script';
 import dynamic from 'next/dynamic';
 
 const ServiceWorkerRegister = dynamic(() => import('@components/ServiceWorkerRegister'));
+
+const DynamicToaster = dynamic(() => import('@/components/common/DynamicToaster'));
 
 const pretendard = localFont({
   src: '../fonts/PretendardVariable.woff2',
@@ -60,7 +61,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </div>
           </OptimizedClientLayout>
         </Providers>
-        <Toaster />
+        <DynamicToaster />
         <ServiceWorkerRegister />
       </body>
     </html>

--- a/src/components/common/DynamicToaster.tsx
+++ b/src/components/common/DynamicToaster.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const ToasterComponent = dynamic(
+  () => import('react-hot-toast').then((mod) => ({ default: mod.Toaster })),
+  {
+    ssr: false,
+  },
+);
+
+export default function DynamicToaster() {
+  return <ToasterComponent />;
+}


### PR DESCRIPTION
### 🚀 연관된 이슈
- #188
<!-- 작업과 직접 연결된 이슈 번호를 명시해주세요 -->

---

### 📝 작업 내용
Dynamic Import를 활용하여 초기 번들 크기를 감소시키고 First Contentful Paint(FCP)와 Total Blocking Time(TBT)을 개선하는 성능 최적화 작업을 진행했습니다.

**주요 최적화 전략:**
- Root Level 최적화: `react-hot-toast`를 초기 번들에서 분리
- Layout Component 분리: `Header`, `BottomNavigationBar` 등 레이아웃 컴포넌트 동적 로딩
- Modal Component 조건부 로딩: 사용자 상태에 따른 모달 컴포넌트 동적 로딩
- 점진적 로딩 전략: Home 페이지에서 `Above-the-fold vs Below-the-fold `구분 로딩

<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->

---

### 🛠 변경 사항 요약

항목 | 내용
-- | --
기능 유형 | 성능 최적화 / 번들 크기 개선
영향 범위 | 전체 애플리케이션 (특히 Home, Chat 페이지)
관련 파일 | 있음 - layout.tsx, ClientLayoutContent.tsx, home/page.tsx 등
추가 리팩토링 | 없음 - 기존 기능은 그대로 유지하며 로딩 방식만 최적화





### ✅ 테스트 목록

**기능 테스트:**
- [x] Home 페이지 로딩 및 점진적 컨텐츠 표시 확인
- [x] Chat 페이지에서 모달(ConfirmModal, WaitingModal, NewMessageToast) 정상 동작
- [x] Toast 알림 기능 정상 작동 (매칭 수락/거절시)
- [x] Header, BottomNavigationBar 정상 렌더링 및 네비게이션 기능
- [x] 모든 페이지에서 레이아웃 컴포넌트 정상 표시

**성능 테스트:**
- [x] 빌드 성공 및 번들 크기 감소 확인 (455KB → 451KB)
- [x] Home 페이지 번들 크기 25% 감소 확인 (1.35KB → 1.01KB)
- [x] Vendor chunk 5KB 감소 확인 (353KB → 348KB)
- [x] Dynamic Import 청크들이 올바르게 분리되어 생성되는지 확인
- [x] 개발 환경에서 컴포넌트들이 지연 로딩되는지 확인

**브라우저 테스트:**
- [x] Chrome DevTools Network 탭에서 초기 로드 파일 수 감소 확인
- [x] Performance 탭에서 FCP 개선 확인
- [x] 콘솔에서 성능 모니터링 로그 정상 출력 확인

---

### 📊 성능 개선 결과
**번들 크기 최적화:**
```
전체 번들:     455KB → 451KB (-4KB, -0.9%)
Vendor chunk:  353KB → 348KB (-5KB, -1.4%)
Common chunk:  99.2KB → 100KB (+0.8KB)
Home 페이지:   1.35KB → 1.01KB (-0.34KB, -25%)
```
**로딩 전략 개선:**
```
즉시 로드:     핵심 UI, ClickWebPushBanner
300ms 지연:    BannerSection (embla-carousel 포함)
500ms 지연:    MatchTypeSelector (사용자 인터랙션)
조건부 로드:   모달 컴포넌트들 (필요시에만)
```

### 📎 참고 자료
- https://nextjs.org/docs/app/guides/lazy-loading
<!-- 디자인 시안, 기획 문서, 관련 링크 등 참고할 만한 자료가 있다면 첨부해주세요
- [Figma 시안](https://figma.com/xyz)
- [기획 노션 문서](https://notion.so/project/abc) -->